### PR TITLE
More cases to optimize linq

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add SECURITY.md ([#1147](https://github.com/josefpihrt/roslynator/pull/1147))
+- Support for more linq optimizations ([#1157](https://github.com/josefpihrt/roslynator/pull/1157))
 
 ### Fixed
 

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
@@ -334,10 +334,8 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
 
         SimpleNameSyntax name = (invocationInfo2.NameText, invocationInfo.NameText) switch
         {
-            ("OrderBy", "Min") => (SimpleNameSyntax)ParseName("MinBy"),
-            ("OrderBy", "Max") => (SimpleNameSyntax)ParseName("MaxBy"),
-            ("OrderByDescending", "Min") => (SimpleNameSyntax)ParseName("MaxBy"),
-            ("OrderByDescending", "Max") => (SimpleNameSyntax)ParseName("MinBy"),
+            ("OrderBy", "FirstOrDefault") => (SimpleNameSyntax)ParseName("MinBy"),
+            ("OrderByDescending", "FirstOrDefault") => (SimpleNameSyntax)ParseName("MaxBy"),
             _ => invocationInfo.Name
         };
 

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
@@ -332,8 +332,17 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
         InvocationExpressionSyntax invocation = invocationInfo.InvocationExpression;
         InvocationExpressionSyntax invocation2 = invocationInfo2.InvocationExpression;
 
+        SimpleNameSyntax name = (invocationInfo2.NameText, invocationInfo.NameText) switch
+        {
+            ("OrderBy", "Min") => (SimpleNameSyntax)ParseName("MinBy"),
+            ("OrderBy", "Max") => (SimpleNameSyntax)ParseName("MaxBy"),
+            ("OrderByDescending", "Min") => (SimpleNameSyntax)ParseName("MaxBy"),
+            ("OrderByDescending", "Max") => (SimpleNameSyntax)ParseName("MinBy"),
+            _ => invocationInfo.Name
+        };
+
         InvocationExpressionSyntax newNode = invocation2.WithExpression(
-            invocationInfo2.MemberAccessExpression.WithName(invocationInfo.Name.WithTriviaFrom(invocationInfo2.Name)));
+            invocationInfo2.MemberAccessExpression.WithName(name.WithTriviaFrom(invocationInfo2.Name)));
 
         IEnumerable<SyntaxTrivia> trivia = invocation.DescendantTrivia(TextSpan.FromBounds(invocation2.Span.End, invocation.Span.End));
 

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
@@ -336,6 +336,8 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
         {
             ("OrderBy", "FirstOrDefault") => (SimpleNameSyntax)ParseName("MinBy"),
             ("OrderByDescending", "FirstOrDefault") => (SimpleNameSyntax)ParseName("MaxBy"),
+            ("OrderBy", "First") => (SimpleNameSyntax)ParseName("MinBy"),
+            ("OrderByDescending", "First") => (SimpleNameSyntax)ParseName("MaxBy"),
             _ => invocationInfo.Name
         };
 

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/SimplifyLogicalNegationCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/SimplifyLogicalNegationCodeFixProvider.cs
@@ -97,9 +97,9 @@ public sealed class SimplifyLogicalNegationCodeFixProvider : BaseCodeFixProvider
 
                     SingleParameterLambdaExpressionInfo lambdaInfo = SyntaxInfo.SingleParameterLambdaExpressionInfo(lambdaExpression);
 
-                    var logicalNot2 = SimplifyLogicalNegationAnalyzer.GetReturnExpression(lambdaInfo.Body).WalkDownParentheses();
+                    ExpressionSyntax logicalNot2 = SimplifyLogicalNegationAnalyzer.GetReturnExpression(lambdaInfo.Body).WalkDownParentheses();
 
-                    var invertedExperssion = SyntaxLogicalInverter.GetInstance(document).LogicallyInvert(logicalNot2);
+                    ExpressionSyntax invertedExperssion = SyntaxLogicalInverter.GetInstance(document).LogicallyInvert(logicalNot2);
 
                     InvocationExpressionSyntax newNode = invocationExpression.ReplaceNode(logicalNot2, invertedExperssion.WithTriviaFrom(logicalNot2));
 

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/SimplifyLogicalNegationCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/SimplifyLogicalNegationCodeFixProvider.cs
@@ -97,9 +97,11 @@ public sealed class SimplifyLogicalNegationCodeFixProvider : BaseCodeFixProvider
 
                     SingleParameterLambdaExpressionInfo lambdaInfo = SyntaxInfo.SingleParameterLambdaExpressionInfo(lambdaExpression);
 
-                    var logicalNot2 = (PrefixUnaryExpressionSyntax)SimplifyLogicalNegationAnalyzer.GetReturnExpression(lambdaInfo.Body).WalkDownParentheses();
+                    var logicalNot2 = SimplifyLogicalNegationAnalyzer.GetReturnExpression(lambdaInfo.Body).WalkDownParentheses();
 
-                    InvocationExpressionSyntax newNode = invocationExpression.ReplaceNode(logicalNot2, logicalNot2.Operand.WithTriviaFrom(logicalNot2));
+                    var invertedExperssion = SyntaxLogicalInverter.GetInstance(document).LogicallyInvert(logicalNot2);
+
+                    InvocationExpressionSyntax newNode = invocationExpression.ReplaceNode(logicalNot2, invertedExperssion.WithTriviaFrom(logicalNot2));
 
                     return SyntaxRefactorings.ChangeInvokedMethodName(newNode, (memberAccessExpression.Name.Identifier.ValueText == "All") ? "Any" : "All");
                 }

--- a/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
@@ -137,7 +137,7 @@ public sealed class InvocationExpressionAnalyzer : BaseDiagnosticAnalyzer
                         case "Min":
                             {
                                 if (DiagnosticRules.OptimizeLinqMethodCall.IsEffective(context))
-                                    OptimizeLinqMethodCallAnalysis.AnalyzeSelectAndMinOrMax(context, invocationInfo);
+                                    OptimizeLinqMethodCallAnalysis.AnalyzeMinOrMax(context, invocationInfo);
 
                                 break;
                             }

--- a/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
@@ -270,9 +270,7 @@ public sealed class InvocationExpressionAnalyzer : BaseDiagnosticAnalyzer
                         case "FirstOrDefault":
                             {
                                 if (DiagnosticRules.OptimizeLinqMethodCall.IsEffective(context))
-                                {
                                     OptimizeLinqMethodCallAnalysis.AnalyzeFirstOrDefault(context, invocationInfo);
-                                }
 
                                 break;
                             }

--- a/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
@@ -129,6 +129,7 @@ public sealed class InvocationExpressionAnalyzer : BaseDiagnosticAnalyzer
 
                                     OptimizeLinqMethodCallAnalysis.AnalyzeWhere(context, invocationInfo);
                                     OptimizeLinqMethodCallAnalysis.AnalyzeFirst(context, invocationInfo);
+                                    OptimizeLinqMethodCallAnalysis.AnalyzerOrderByAndFirst(context, invocationInfo, shouldThrowIfEmpty: true);
                                 }
 
                                 break;
@@ -184,7 +185,7 @@ public sealed class InvocationExpressionAnalyzer : BaseDiagnosticAnalyzer
                                 {
                                     OptimizeLinqMethodCallAnalysis.AnalyzeWhere(context, invocationInfo);
                                     OptimizeLinqMethodCallAnalysis.AnalyzeFirstOrDefault(context, invocationInfo);
-                                    OptimizeLinqMethodCallAnalysis.AnalyzerOrderByAndFirstOrDefault(context, invocationInfo);
+                                    OptimizeLinqMethodCallAnalysis.AnalyzerOrderByAndFirst(context, invocationInfo, shouldThrowIfEmpty: false);
                                 }
 
                                 break;

--- a/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
@@ -137,7 +137,7 @@ public sealed class InvocationExpressionAnalyzer : BaseDiagnosticAnalyzer
                         case "Min":
                             {
                                 if (DiagnosticRules.OptimizeLinqMethodCall.IsEffective(context))
-                                    OptimizeLinqMethodCallAnalysis.AnalyzeMinOrMax(context, invocationInfo);
+                                    OptimizeLinqMethodCallAnalysis.AnalyzeSelectAndMinOrMax(context, invocationInfo);
 
                                 break;
                             }
@@ -184,6 +184,7 @@ public sealed class InvocationExpressionAnalyzer : BaseDiagnosticAnalyzer
                                 {
                                     OptimizeLinqMethodCallAnalysis.AnalyzeWhere(context, invocationInfo);
                                     OptimizeLinqMethodCallAnalysis.AnalyzeFirstOrDefault(context, invocationInfo);
+                                    OptimizeLinqMethodCallAnalysis.AnalyzerOrderByAndFirstOrDefault(context, invocationInfo);
                                 }
 
                                 break;
@@ -269,7 +270,9 @@ public sealed class InvocationExpressionAnalyzer : BaseDiagnosticAnalyzer
                         case "FirstOrDefault":
                             {
                                 if (DiagnosticRules.OptimizeLinqMethodCall.IsEffective(context))
+                                {
                                     OptimizeLinqMethodCallAnalysis.AnalyzeFirstOrDefault(context, invocationInfo);
+                                }
 
                                 break;
                             }

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -203,19 +203,19 @@ internal static class OptimizeLinqMethodCallAnalysis
                     break;
                 }
             case "OrderBy":
-            {
-                if (!SymbolUtility.IsLinqOrderBy(methodSymbol2, allowImmutableArrayExtension: true))
-                    return;
-                
-                break;
-            }
+                {
+                    if (!SymbolUtility.IsLinqOrderBy(methodSymbol2, allowImmutableArrayExtension: true))
+                        return;
+
+                    break;
+                }
             case "OrderByDescending":
-            {
-                if (!SymbolUtility.IsLinqOrderByDescending(methodSymbol2, allowImmutableArrayExtension: true))
-                    return;
-                
-                break;
-            }
+                {
+                    if (!SymbolUtility.IsLinqOrderByDescending(methodSymbol2, allowImmutableArrayExtension: true))
+                        return;
+
+                    break;
+                }
             default:
                 {
                     Debug.Fail(methodName);

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -105,9 +105,7 @@ internal static class OptimizeLinqMethodCallAnalysis
     }
 
     // items.Select(selector).Min/Max() >>> items.Min/Max(selector)
-    // items.OrderBy(selector).Min/Max() >>> items.MinBy/MaxBy(selector)
-    // items.OrderByDescending(selector).Min/Max() >>> items.MaxBy/MinBy(selector)
-    public static void AnalyzeMinOrMax(
+    public static void AnalyzeSelectAndMinOrMax(
         SyntaxNodeAnalysisContext context,
         in SimpleMemberInvocationExpressionInfo invocationInfo)
     {
@@ -116,19 +114,6 @@ internal static class OptimizeLinqMethodCallAnalysis
             invocationInfo,
             "Select",
             Properties.SimplifyLinqMethodChain);
-
-        SimplifyLinqMethodChain(
-            context,
-            invocationInfo,
-            "OrderBy",
-            Properties.SimplifyLinqMethodChain);
-
-        SimplifyLinqMethodChain(
-            context,
-            invocationInfo,
-            "OrderByDescending",
-            Properties.SimplifyLinqMethodChain);
-
     }
 
     // list.Select(selector).ToList() >>> list.ConvertAll(selector)
@@ -226,6 +211,24 @@ internal static class OptimizeLinqMethodCallAnalysis
         TextSpan span = TextSpan.FromBounds(invocationInfo2.Name.SpanStart, invocation.Span.End);
 
         Report(context, invocation, span, checkDirectives: true, properties: properties);
+    }
+
+    // items.OrderBy(selector).FirstOrDefault() >>> items.MaxBy(selector)
+    // items.OrderByDescending(selector).FirstOrDefault() >>> items.MaxBy(selector)
+    public static void AnalyzerOrderByAndFirstOrDefault(SyntaxNodeAnalysisContext context,
+        in SimpleMemberInvocationExpressionInfo invocationInfo)
+    {
+        SimplifyLinqMethodChain(
+            context,
+            invocationInfo,
+            "OrderBy",
+            Properties.SimplifyLinqMethodChain);
+
+        SimplifyLinqMethodChain(
+            context,
+            invocationInfo,
+            "OrderByDescending",
+            Properties.SimplifyLinqMethodChain);
     }
 
     public static void AnalyzeFirstOrDefault(SyntaxNodeAnalysisContext context, in SimpleMemberInvocationExpressionInfo invocationInfo)

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -221,10 +221,10 @@ internal static class OptimizeLinqMethodCallAnalysis
 
         foreach (var attr in compilation.Assembly.GetAttributes())
         {
-            if (!SymbolEqualityComparer.Default.Equals(targetFrameworkAttribute,attr.AttributeClass))
+            if (!SymbolEqualityComparer.Default.Equals(targetFrameworkAttribute, attr.AttributeClass))
                 continue;
 
-            if(attr.ConstructorArguments.FirstOrDefault().Value is not string targetFramework)
+            if (attr.ConstructorArguments.FirstOrDefault().Value is not string targetFramework)
                 continue;
 
             if (targetFramework is ".NETCoreApp,Version=v6.0" or ".NETCoreApp,Version=v7.0")

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -213,33 +213,13 @@ internal static class OptimizeLinqMethodCallAnalysis
         Report(context, invocation, span, checkDirectives: true, properties: properties);
     }
 
-    private static bool IsNet6OrGreater(Compilation compilation)
-    {
-        var targetFrameworkAttribute = compilation.GetTypeByMetadataName("System.Runtime.Versioning.TargetFrameworkAttribute");
-
-        if (targetFrameworkAttribute == null)
-            return false;
-
-        foreach (var attr in compilation.Assembly.GetAttributes())
-        {
-            if (!SymbolEqualityComparer.Default.Equals(targetFrameworkAttribute, attr.AttributeClass))
-                continue;
-
-            if (attr.ConstructorArguments.FirstOrDefault().Value is not string targetFramework)
-                continue;
-
-            if (targetFramework is ".NETCoreApp,Version=v6.0" or ".NETCoreApp,Version=v7.0")
-                return true;
-        }
-
-        return false;
-    }
-
     // items.OrderBy(selector).FirstOrDefault() >>> items.MaxBy(selector)
     // items.OrderByDescending(selector).FirstOrDefault() >>> items.MaxBy(selector)
     public static void AnalyzerOrderByAndFirstOrDefault(SyntaxNodeAnalysisContext context, in SimpleMemberInvocationExpressionInfo invocationInfo)
     {
-        if (!IsNet6OrGreater(context.Compilation))
+        INamedTypeSymbol enumerableSymbol = context.Compilation.GetTypeByMetadataName("System.Linq.Enumerable");
+
+        if (enumerableSymbol.FindMember<IMethodSymbol>("MinBy") is null)
             return;
 
         SimplifyLinqMethodChain(

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -105,7 +105,9 @@ internal static class OptimizeLinqMethodCallAnalysis
     }
 
     // items.Select(selector).Min/Max() >>> items.Min/Max(selector)
-    public static void AnalyzeSelectAndMinOrMax(
+    // items.OrderBy(selector).Min/Max() >>> items.MinBy/MaxBy(selector)
+    // items.OrderByDescending(selector).Min/Max() >>> items.MaxBy/MinBy(selector)
+    public static void AnalyzeMinOrMax(
         SyntaxNodeAnalysisContext context,
         in SimpleMemberInvocationExpressionInfo invocationInfo)
     {
@@ -114,6 +116,19 @@ internal static class OptimizeLinqMethodCallAnalysis
             invocationInfo,
             "Select",
             Properties.SimplifyLinqMethodChain);
+
+        SimplifyLinqMethodChain(
+            context,
+            invocationInfo,
+            "OrderBy",
+            Properties.SimplifyLinqMethodChain);
+
+        SimplifyLinqMethodChain(
+            context,
+            invocationInfo,
+            "OrderByDescending",
+            Properties.SimplifyLinqMethodChain);
+
     }
 
     // list.Select(selector).ToList() >>> list.ConvertAll(selector)
@@ -187,6 +202,20 @@ internal static class OptimizeLinqMethodCallAnalysis
 
                     break;
                 }
+            case "OrderBy":
+            {
+                if (!SymbolUtility.IsLinqOrderBy(methodSymbol2, allowImmutableArrayExtension: true))
+                    return;
+                
+                break;
+            }
+            case "OrderByDescending":
+            {
+                if (!SymbolUtility.IsLinqOrderByDescending(methodSymbol2, allowImmutableArrayExtension: true))
+                    return;
+                
+                break;
+            }
             default:
                 {
                     Debug.Fail(methodName);

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -215,8 +215,7 @@ internal static class OptimizeLinqMethodCallAnalysis
 
     // items.OrderBy(selector).FirstOrDefault() >>> items.MaxBy(selector)
     // items.OrderByDescending(selector).FirstOrDefault() >>> items.MaxBy(selector)
-    public static void AnalyzerOrderByAndFirstOrDefault(SyntaxNodeAnalysisContext context,
-        in SimpleMemberInvocationExpressionInfo invocationInfo)
+    public static void AnalyzerOrderByAndFirstOrDefault(SyntaxNodeAnalysisContext context, in SimpleMemberInvocationExpressionInfo invocationInfo)
     {
         SimplifyLinqMethodChain(
             context,

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -217,7 +217,8 @@ internal static class OptimizeLinqMethodCallAnalysis
     {
         var targetFrameworkAttribute = compilation.GetTypeByMetadataName("System.Runtime.Versioning.TargetFrameworkAttribute");
 
-        if (targetFrameworkAttribute == null) return false;
+        if (targetFrameworkAttribute == null)
+            return false;
 
         foreach (var attr in compilation.Assembly.GetAttributes())
         {
@@ -238,7 +239,8 @@ internal static class OptimizeLinqMethodCallAnalysis
     // items.OrderByDescending(selector).FirstOrDefault() >>> items.MaxBy(selector)
     public static void AnalyzerOrderByAndFirstOrDefault(SyntaxNodeAnalysisContext context, in SimpleMemberInvocationExpressionInfo invocationInfo)
     {
-        if (!IsNet6OrGreater(context.Compilation)) return;
+        if (!IsNet6OrGreater(context.Compilation))
+            return;
 
         SimplifyLinqMethodChain(
             context,

--- a/src/Analyzers/CSharp/Analysis/SimplifyLogicalNegationAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/SimplifyLogicalNegationAnalyzer.cs
@@ -173,9 +173,7 @@ public sealed class SimplifyLogicalNegationAnalyzer : BaseDiagnosticAnalyzer
         if (!lambdaInfo.Success)
             return;
 
-        ExpressionSyntax expression = GetReturnExpression(lambdaInfo.Body)?.WalkDownParentheses();
-
-        if (expression?.IsKind(SyntaxKind.LogicalNotExpression) != true)
+        if (GetReturnExpression(lambdaInfo.Body) is null)
             return;
 
         IMethodSymbol methodSymbol = context.SemanticModel.GetReducedExtensionMethodInfo(invocationInfo.InvocationExpression, context.CancellationToken).Symbol;

--- a/src/Core/SymbolUtility.cs
+++ b/src/Core/SymbolUtility.cs
@@ -305,6 +305,20 @@ internal static class SymbolUtility
         return IsLinqExtensionOfIEnumerableOfTWithPredicate(methodSymbol, "Where", parameterCount: 2, allowImmutableArrayExtension: allowImmutableArrayExtension);
     }
 
+    internal static bool IsLinqOrderBy(
+        IMethodSymbol methodSymbol,
+        bool allowImmutableArrayExtension = false)
+    {
+        return IsLinqExtensionOfIEnumerableOfT(methodSymbol, "OrderBy", parameterCount: 2, allowImmutableArrayExtension: allowImmutableArrayExtension);
+    }
+
+    internal static bool IsLinqOrderByDescending(
+        IMethodSymbol methodSymbol,
+        bool allowImmutableArrayExtension = false)
+    {
+        return IsLinqExtensionOfIEnumerableOfT(methodSymbol, "OrderByDescending", parameterCount: 2, allowImmutableArrayExtension: allowImmutableArrayExtension);
+    }
+
     internal static bool IsLinqWhereWithIndex(IMethodSymbol methodSymbol)
     {
         if (!IsLinqExtensionOfIEnumerableOfT(methodSymbol, "Where", parameterCount: 2, allowImmutableArrayExtension: false))

--- a/src/Tests/Analyzers.Tests/RCS1068SimplifyLogicalNegationTests2.cs
+++ b/src/Tests/Analyzers.Tests/RCS1068SimplifyLogicalNegationTests2.cs
@@ -121,6 +121,40 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.SimplifyLogicalNegation)]
+    public async Task Test_NotAny4()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Linq;
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        bool f1 = false;
+        var items = new List<int>();
+
+        f1 = [|!items.Any(i => i % 2 == 0)|];
+    }
+}
+", @"
+using System.Linq;
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        bool f1 = false;
+        var items = new List<int>();
+
+        f1 = items.All(i => i % 2 != 0);
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.SimplifyLogicalNegation)]
     public async Task Test_NotAll()
     {
         await VerifyDiagnosticAndFixAsync(@"
@@ -223,6 +257,40 @@ class C
         var items = new List<string>();
 
         f1 = items.Any<string>(s => s.Equals(s));
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.SimplifyLogicalNegation)]
+    public async Task Test_NotAll4()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Linq;
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        bool f1 = false;
+        var items = new List<int>();
+
+        f1 = [|!items.All(i => i % 2 == 0)|];
+    }
+}
+", @"
+using System.Linq;
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        bool f1 = false;
+        var items = new List<int>();
+
+        f1 = items.Any(i => i % 2 != 0);
     }
 }
 ");

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -290,17 +290,41 @@ class C
         await VerifyDiagnosticAndFixAsync(@"
 using System.Collections.Generic;
 using System.Linq;
+[assembly: global::System.Runtime.Versioning.TargetFrameworkAttribute("".NETCoreApp,Version=v6.0"", FrameworkDisplayName = "".NET 6.0"")]
 
-class C
+namespace N
 {
-    string M()
+    class C
     {
-        var items = new List<string>();
+        string M()
+        {
+            var items = new List<string>();
 
-        return items.[||];
+            return items.[||];
+        }
     }
-}
-", source, expected);
+}", source, expected);
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
+    public async Task Test_DoesntCombineOrderByFirstOrDefaultForNetstandard()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System.Collections.Generic;
+using System.Linq;
+
+namespace N
+{
+    class C
+    {
+        string M()
+        {
+            var items = new List<string>();
+
+            return items.OrderBy(f => f.Length).FirstOrDefault();
+        }
+    }
+}");
     }
 
     [Theory, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -283,6 +283,29 @@ class C
     }
 
     [Theory, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
+    [InlineData(@"OrderBy(f => f.Length).Max()", @"MaxBy(f => f.Length)")]
+    [InlineData(@"OrderBy(f => f.Length).Min()", @"MinBy(f => f.Length)")]
+    [InlineData(@"OrderByDescending(f => f.Length).Max()", @"MinBy(f => f.Length)")]
+    [InlineData(@"OrderByDescending(f => f.Length).Min()", @"MaxBy(f => f.Length)")]
+    public async Task Test_CombineOrderByMinMax(string source, string expected)
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    string M()
+    {
+        var items = new List<string>();
+
+        return items.[||];
+    }
+}
+", source, expected);
+    }
+
+    [Theory, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
     [InlineData(@"Where(f => f.StartsWith(""a"")).Any(f => f.StartsWith(""b""))", @"Any(f => f.StartsWith(""a"") && f.StartsWith(""b""))")]
     [InlineData(@"Where((f) => f.StartsWith(""a"")).Any(f => f.StartsWith(""b""))", @"Any((f) => f.StartsWith(""a"") && f.StartsWith(""b""))")]
     public async Task Test_CombineWhereAndAny_ImmutableArray(string source, string expected)

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -283,11 +283,9 @@ class C
     }
 
     [Theory, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
-    [InlineData(@"OrderBy(f => f.Length).Max()", @"MaxBy(f => f.Length)")]
-    [InlineData(@"OrderBy(f => f.Length).Min()", @"MinBy(f => f.Length)")]
-    [InlineData(@"OrderByDescending(f => f.Length).Max()", @"MinBy(f => f.Length)")]
-    [InlineData(@"OrderByDescending(f => f.Length).Min()", @"MaxBy(f => f.Length)")]
-    public async Task Test_CombineOrderByMinMax(string source, string expected)
+    [InlineData(@"OrderBy(f => f.Length).FirstOrDefault()", @"MinBy(f => f.Length)")]
+    [InlineData(@"OrderByDescending(f => f.Length).FirstOrDefault()", @"MaxBy(f => f.Length)")]
+    public async Task Test_CombineOrderByFirstOrDefault(string source, string expected)
     {
         await VerifyDiagnosticAndFixAsync(@"
 using System.Collections.Generic;

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -283,8 +283,8 @@ class C
     }
 
     [Theory, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
-    [InlineData(@"OrderBy(f => f.Length).FirstOrDefault()", @"MinBy(f => f.Length)")]
-    [InlineData(@"OrderByDescending(f => f.Length).FirstOrDefault()", @"MaxBy(f => f.Length)")]
+    [InlineData("OrderBy(f => f.Length).FirstOrDefault()", "MinBy(f => f.Length)")]
+    [InlineData("OrderByDescending(f => f.Length).FirstOrDefault()", "MaxBy(f => f.Length)")]
     public async Task Test_CombineOrderByFirstOrDefault(string source, string expected)
     {
         await VerifyDiagnosticAndFixAsync(@"

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -290,7 +290,6 @@ class C
         await VerifyDiagnosticAndFixAsync(@"
 using System.Collections.Generic;
 using System.Linq;
-[assembly: global::System.Runtime.Versioning.TargetFrameworkAttribute("".NETCoreApp,Version=v6.0"", FrameworkDisplayName = "".NET 6.0"")]
 
 namespace N
 {
@@ -305,28 +304,7 @@ namespace N
     }
 }", source, expected);
     }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
-    public async Task Test_DoesntCombineOrderByFirstOrDefaultForNetstandard()
-    {
-        await VerifyNoDiagnosticAsync(@"
-using System.Collections.Generic;
-using System.Linq;
-
-namespace N
-{
-    class C
-    {
-        string M()
-        {
-            var items = new List<string>();
-
-            return items.OrderBy(f => f.Length).FirstOrDefault();
-        }
-    }
-}");
-    }
-
+    
     [Theory, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
     [InlineData(@"Where(f => f.StartsWith(""a"")).Any(f => f.StartsWith(""b""))", @"Any(f => f.StartsWith(""a"") && f.StartsWith(""b""))")]
     [InlineData(@"Where((f) => f.StartsWith(""a"")).Any(f => f.StartsWith(""b""))", @"Any((f) => f.StartsWith(""a"") && f.StartsWith(""b""))")]


### PR DESCRIPTION
Adds support for the following transformations:
```
OrderBy(...).FirstOrDefault() => MinBy(...)
OrderByDescending(...).FirstOrDefault() => MaxBy(...)
```

Do not restrict Applying Demorgans laws to the cases when the inside of the All / Any invocation is of the form !(...) - We can invert any boolean expression using SyntaxLogicalInverter.
