### PR TITLE
Fixed DeclareAsNullableCodeFixProvider for casts in variable declarations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix analyzer [RCS0049](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0049) ([PR](https://github.com/dotnet/roslynator/pull/1386))
 - Fix analyzer [RCS1159](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1159) ([PR](https://github.com/dotnet/roslynator/pull/1390))
+- Fix code fix for [CS8600](https://josefpihrt.github.io/docs/roslynator/fixes/CS8600) changing the wrong type when casts or `var` are involved ([PR](https://github.com/dotnet/roslynator/pull/1393))
 
 ## [4.10.0] - 2024-01-24
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix analyzer [RCS0049](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0049) ([PR](https://github.com/dotnet/roslynator/pull/1386))
 - Fix analyzer [RCS1159](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1159) ([PR](https://github.com/dotnet/roslynator/pull/1390))
-- Fix code fix for [CS8600](https://josefpihrt.github.io/docs/roslynator/fixes/CS8600) changing the wrong type when casts or `var` are involved ([PR](https://github.com/dotnet/roslynator/pull/1393))
+- Fix code fix for [CS8600](https://josefpihrt.github.io/docs/roslynator/fixes/CS8600) changing the wrong type when casts or `var` are involved ([PR](https://github.com/dotnet/roslynator/pull/1393) by @jroessel)
 
 ## [4.10.0] - 2024-01-24
 

--- a/src/CodeFixes/CSharp/CodeFixes/DeclareAsNullableCodeFixProvider.cs
+++ b/src/CodeFixes/CSharp/CodeFixes/DeclareAsNullableCodeFixProvider.cs
@@ -120,6 +120,7 @@ public sealed class DeclareAsNullableCodeFixProvider : CompilerDiagnosticCodeFix
                     VariableDeclarationSyntax newVariableDeclaration = variableDeclaration
                         .ReplaceNode(type, newType)
                         .WithType(newDeclarationType);
+
                     return await context.Document.ReplaceNodeAsync(variableDeclaration, newVariableDeclaration, ct).ConfigureAwait(false);
                 }
                 else

--- a/src/Tests/CodeFixes.Tests/CS8600ConvertingNullLiteralOrPossibleNullValueToNonNullableTypeTests.cs
+++ b/src/Tests/CodeFixes.Tests/CS8600ConvertingNullLiteralOrPossibleNullValueToNonNullableTypeTests.cs
@@ -43,6 +43,40 @@ public class C
     }
 
     [Fact, Trait(Traits.CodeFix, CompilerDiagnosticIdentifiers.CS8600_ConvertingNullLiteralOrPossibleNullValueToNonNullableType)]
+    public async Task Test_LocalDeclarationWithCast()
+    {
+        await VerifyFixAsync(@"
+using System;
+#nullable enable
+
+public class C
+{
+    private object? Get() => null;
+
+    void M()
+    {
+      var s = (string) Get();
+      string s2 = (string) Get();
+    }
+}
+", @"
+using System;
+#nullable enable
+
+public class C
+{
+    private object? Get() => null;
+
+    void M()
+    {
+      var s = (string?) Get();
+      string? s2 = (string?) Get();
+    }
+}
+", equivalenceKey: EquivalenceKey.Create(DiagnosticId));
+    }
+
+    [Fact, Trait(Traits.CodeFix, CompilerDiagnosticIdentifiers.CS8600_ConvertingNullLiteralOrPossibleNullValueToNonNullableType)]
     public async Task Test_DeclarationExpression()
     {
         await VerifyFixAsync(@"


### PR DESCRIPTION
Casting a nullable type to a non-nullable type within a variable declaration no longer ignores the cast type and also no longer changes `var` to `var?`.

Fixes #1392.

The code got a little convoluted and the necessity to change two types at the same time required a separate method. I'm still not sure whether there's a good way of queuing two different fixes at the same time, as you can't find your syntax nodes anymore. I hope it's okay enough, though.