### PR TITLE
Fix minor typo and re-generate documentation-related files.

### DIFF
--- a/src/CodeFixes/CSharp/CompilerDiagnosticRules.Generated.cs
+++ b/src/CodeFixes/CSharp/CompilerDiagnosticRules.Generated.cs
@@ -2027,7 +2027,7 @@ namespace Roslynator.CSharp
         /// <summary>CS8403</summary>
         public static readonly DiagnosticDescriptor MethodWithIteratorBlockMustBeAsyncToReturnIAsyncEnumerableOfT = new DiagnosticDescriptor(
             id:                 CompilerDiagnosticIdentifiers.CS8403_MethodWithIteratorBlockMustBeAsyncToReturnIAsyncEnumerableOfT, 
-            title:              "Method with an iterator block must be 'async' to return 'IAsyncEnumerable<T<'.", 
+            title:              "Method with an iterator block must be 'async' to return 'IAsyncEnumerable<T>'.", 
             messageFormat:      "Method '{0}' with an iterator block must be 'async' to return '{1}'", 
             category:           "Compiler", 
             defaultSeverity:    DiagnosticSeverity.Error, 

--- a/src/Common/ConfigOptionKeys.Generated.cs
+++ b/src/Common/ConfigOptionKeys.Generated.cs
@@ -30,8 +30,8 @@ namespace Roslynator
         public const string MaxLineLength                                     = "roslynator_max_line_length";
         public const string NewLineAtEndOfFile                                = "roslynator_new_line_at_end_of_file";
         public const string NewLineBeforeWhileInDoStatement                   = "roslynator_new_line_before_while_in_do_statement";
-        public const string NullConditionalOperatorNewLine                    = "roslynator_null_conditional_operator_new_line";
         public const string NullCheckStyle                                    = "roslynator_null_check_style";
+        public const string NullConditionalOperatorNewLine                    = "roslynator_null_conditional_operator_new_line";
         public const string ObjectCreationParenthesesStyle                    = "roslynator_object_creation_parentheses_style";
         public const string ObjectCreationTypeStyle                           = "roslynator_object_creation_type_style";
         public const string PrefixFieldIdentifierWithUnderscore               = "roslynator_prefix_field_identifier_with_underscore";

--- a/src/Common/ConfigOptionValues.Generated.cs
+++ b/src/Common/ConfigOptionValues.Generated.cs
@@ -43,10 +43,10 @@ namespace Roslynator
         public const string EqualsTokenNewLine_Before                                                   = "before";
         public const string InfiniteLoopStyle_For                                                       = "for";
         public const string InfiniteLoopStyle_While                                                     = "while";
-        public const string NullConditionalOperatorNewLine_After                                        = "after";
-        public const string NullConditionalOperatorNewLine_Before                                       = "before";
         public const string NullCheckStyle_EqualityOperator                                             = "equality_operator";
         public const string NullCheckStyle_PatternMatching                                              = "pattern_matching";
+        public const string NullConditionalOperatorNewLine_After                                        = "after";
+        public const string NullConditionalOperatorNewLine_Before                                       = "before";
         public const string ObjectCreationParenthesesStyle_Include                                      = "include";
         public const string ObjectCreationParenthesesStyle_Omit                                         = "omit";
         public const string ObjectCreationTypeStyle_Explicit                                            = "explicit";

--- a/src/Common/ConfigOptions.Generated.cs
+++ b/src/Common/ConfigOptions.Generated.cs
@@ -153,17 +153,17 @@ namespace Roslynator
             defaultValuePlaceholder: "true|false", 
             description:             "Include/omit new line before 'while' in 'do' statement");
 
-        public static readonly ConfigOptionDescriptor NullConditionalOperatorNewLine = new(
-            key:                     ConfigOptionKeys.NullConditionalOperatorNewLine, 
-            defaultValue:            null, 
-            defaultValuePlaceholder: "after|before", 
-            description:             "Place new line after/before null-conditional operator");
-
         public static readonly ConfigOptionDescriptor NullCheckStyle = new(
             key:                     ConfigOptionKeys.NullCheckStyle, 
             defaultValue:            null, 
             defaultValuePlaceholder: "equality_operator|pattern_matching", 
             description:             "Use equality operator or pattern matching as a null check");
+
+        public static readonly ConfigOptionDescriptor NullConditionalOperatorNewLine = new(
+            key:                     ConfigOptionKeys.NullConditionalOperatorNewLine, 
+            defaultValue:            null, 
+            defaultValuePlaceholder: "after|before", 
+            description:             "Place new line after/before null-conditional operator");
 
         public static readonly ConfigOptionDescriptor ObjectCreationParenthesesStyle = new(
             key:                     ConfigOptionKeys.ObjectCreationParenthesesStyle, 

--- a/src/Diagnostics.xml
+++ b/src/Diagnostics.xml
@@ -1180,7 +1180,7 @@
     Id="CS8403"
     Identifier="MethodWithIteratorBlockMustBeAsyncToReturnIAsyncEnumerableOfT"
     Severity="Error"
-    Title="Method with an iterator block must be 'async' to return 'IAsyncEnumerable&lt;T&lt;'."
+    Title="Method with an iterator block must be 'async' to return 'IAsyncEnumerable&lt;T&gt;'."
     Message="Method '{0}' with an iterator block must be 'async' to return '{1}'"
     HelpUrl="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs8403" />
   <Diagnostic

--- a/src/VisualStudioCode/package/src/configurationFiles.generated.ts
+++ b/src/VisualStudioCode/package/src/configurationFiles.generated.ts
@@ -106,11 +106,11 @@ roslynator_analyzers.enabled_by_default = true|false
 #roslynator_new_line_before_while_in_do_statement = true|false
 # Applicable to: rcs0051
 
-#roslynator_null_conditional_operator_new_line = after|before
-# Applicable to: rcs0059
-
 #roslynator_null_check_style = equality_operator|pattern_matching
 # Applicable to: rcs1248
+
+#roslynator_null_conditional_operator_new_line = after|before
+# Applicable to: rcs0059
 
 #roslynator_object_creation_parentheses_style = include|omit
 # Applicable to: rcs1050
@@ -973,6 +973,11 @@ roslynator_analyzers.enabled_by_default = true|false
 #roslynator_refactoring.add_using_static_directive.enabled = true
 #roslynator_refactoring.call_extension_method_as_instance_method.enabled = true
 #roslynator_refactoring.call_indexof_instead_of_contains.enabled = true
+#roslynator_refactoring.change_accessibility.enabled = true
+#roslynator_refactoring.change_method_return_type_to_void.enabled = true
+#roslynator_refactoring.change_type_according_to_expression.enabled = true
+#roslynator_refactoring.check_expression_for_null.enabled = true
+#roslynator_refactoring.check_parameter_for_null.enabled = true
 #roslynator_refactoring.comment_out_member_declaration.enabled = true
 #roslynator_refactoring.comment_out_statement.enabled = true
 #roslynator_refactoring.convert_auto_property_to_full_property.enabled = true
@@ -1027,11 +1032,6 @@ roslynator_analyzers.enabled_by_default = true|false
 #roslynator_refactoring.generate_enum_values.enabled = true
 #roslynator_refactoring.generate_event_invoking_method.enabled = true
 #roslynator_refactoring.generate_property_for_debuggerdisplay_attribute.enabled = true
-#roslynator_refactoring.change_accessibility.enabled = true
-#roslynator_refactoring.change_method_return_type_to_void.enabled = true
-#roslynator_refactoring.change_type_according_to_expression.enabled = true
-#roslynator_refactoring.check_expression_for_null.enabled = true
-#roslynator_refactoring.check_parameter_for_null.enabled = true
 #roslynator_refactoring.implement_custom_enumerator.enabled = true
 #roslynator_refactoring.implement_iequatable.enabled = true
 #roslynator_refactoring.initialize_field_from_constructor.enabled = true


### PR DESCRIPTION
Noticed a typo in the documentation for CS8403, the title for which reads:

Method with an iterator block must be 'async' to return 'IAsyncEnumerable<T<'.

Obviously that should be a `>` not a `<` character at the end.