### PR TITLE
Implement analysis and fix for OrderBy(x => x) to Order()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Analyzer [RCS1077](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1077) now suggests to use `Order` instead of `OrderBy` ([PR](https://github.com/dotnet/roslynator/pull/1522))
+
 ### Fixed
 
 - Fix analyzer [RCS0053](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0053) ([PR](https://github.com/dotnet/roslynator/pull/1518))
@@ -111,12 +115,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - These packages are recommended to be used in an environment where Roslynator IDE extension cannot be used, e.g. VS Code + C# Dev Kit (see related [issue](https://github.com/dotnet/vscode-csharp/issues/6790))
 - Add analyzer "Remove redundant catch block" [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) ([PR](https://github.com/dotnet/roslynator/pull/1364) by @jakubreznak)
 - [CLI] Spellcheck file names ([PR](https://github.com/dotnet/roslynator/pull/1368))
-  - `roslynator spellcheck --scope file-name` 
+  - `roslynator spellcheck --scope file-name`
 
 ### Changed
 
 - Update analyzer [RCS1197](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1197) ([PR](https://github.com/dotnet/roslynator/pull/1370))
-  - Do not report interpolated string and string concatenation 
+  - Do not report interpolated string and string concatenation
 
 ### Fixed
 
@@ -180,7 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add analyzer "Unnecessary raw string literal" ([RCS1262](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1262)) ([PR](https://github.com/dotnet/roslynator/pull/1293))
 - Add analyzer "Invalid reference in a documentation comment" ([RCS1263](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1263)) ([PR](https://github.com/dotnet/roslynator/pull/1295))
 - Add analyzer "Add/remove blank line between switch sections" ([RCS0061](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0061)) ([PR](https://github.com/dotnet/roslynator/pull/1302))
-  - Option (required): `roslynator_blank_line_between_switch_sections = include|omit|omit_after_block` 
+  - Option (required): `roslynator_blank_line_between_switch_sections = include|omit|omit_after_block`
   - Make analyzer [RCS0014](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0014) obsolete
 
 ### Changed
@@ -270,7 +274,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update logo ([PR](https://github.com/dotnet/roslynator/pull/1208), [PR](https://github.com/dotnet/roslynator/pull/1210)).
 - Migrate to .NET Foundation ([PR](https://github.com/dotnet/roslynator/pull/1206), [PR](https://github.com/dotnet/roslynator/pull/1207), [PR](https://github.com/dotnet/roslynator/pull/1219)).
 - Bump Roslyn to 4.7.0 ([PR](https://github.com/dotnet/roslynator/pull/1218)).
-  - Applies to CLI and testing library. 
+  - Applies to CLI and testing library.
 - Bump Microsoft.Build.Locator to 1.6.1 ([PR](https://github.com/dotnet/roslynator/pull/1194))
 - Improve testing framework ([PR](https://github.com/dotnet/roslynator/pull/1214))
   - Add methods to `DiagnosticVerifier`, `RefactoringVerifier` and `CompilerDiagnosticFixVerifier`.
@@ -610,7 +614,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 3.0.0 (2020-06-16)
 
 * Update references to Roslyn API to 3.5.0
-* Release .NET Core Global Tool [Roslynator.DotNet.Cli](https://www.nuget.org/packages/roslynator.dotnet.cli) 
+* Release .NET Core Global Tool [Roslynator.DotNet.Cli](https://www.nuget.org/packages/roslynator.dotnet.cli)
 * Introduce concept of "[Analyzer Options](https://github.com/JosefPihrt/Roslynator/blob/main/docs/AnalyzerOptions)"
 * Reassign ID for some analyzers.
   * See "[How to: Migrate Analyzers to Version 3.0](https://github.com/JosefPihrt/Roslynator/blob/main/docs/HowToMigrateAnalyzersToVersion3)"
@@ -2169,13 +2173,13 @@ Code fixes has been added for the following compiler diagnostics:
 * Bug fixed in **"Uncomment"** refactoring
 
 ### 0.9.11 (2016-04-30)
- 
+
 * Bug fixes and minor improvements
- 
+
 ### 0.9.1 (2016-04-27)
- 
+
 * Bug fixes
- 
+
 ### 0.9.0 (2016-04-26)
- 
+
 * Initial release

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
@@ -582,9 +582,9 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
     {
         InvocationExpressionSyntax newInvocationExpression = ChangeInvokedMethodName(invocationInfo.InvocationExpression, "Order");
 
-        InvocationExpressionSyntax newerInvocationExpression = newInvocationExpression.RemoveNodes(newInvocationExpression.ArgumentList.Arguments, SyntaxRemoveOptions.KeepExteriorTrivia);
+        newInvocationExpression = newInvocationExpression.WithArgumentList(newInvocationExpression.ArgumentList.WithArguments(SeparatedList<ArgumentSyntax>()));
 
-        return document.ReplaceNodeAsync(invocationInfo.InvocationExpression, newerInvocationExpression, cancellationToken);
+        return document.ReplaceNodeAsync(invocationInfo.InvocationExpression, newInvocationExpression, cancellationToken);
     }
 
     private static Task<Document> CallOrderByAndWhereInReverseOrderAsync(

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
@@ -273,7 +273,7 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
                 case "OrderBy":
                     {
                         CodeAction codeAction = CodeAction.Create(
-                            "Call 'Order()' instead of 'OrderBy(x => x)'",
+                            "Call 'Order' instead of 'OrderBy'",
                             ct => CallOrderInsteadOfOrderByIdentityAsync(document, invocationInfo, ct),
                             GetEquivalenceKey(diagnostic, "CallOrderInsteadOfOrderByIdentity"));
 
@@ -580,7 +580,8 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
         in SimpleMemberInvocationExpressionInfo invocationInfo,
         CancellationToken cancellationToken)
     {
-        InvocationExpressionSyntax newInvocationExpression = ChangeInvokedMethodName(invocationInfo.InvocationExpression, "Order");
+        InvocationExpressionSyntax newInvocationExpression = ChangeInvokedMethodName(invocationInfo.InvocationExpression, "Order")
+            .AddArgumentListArguments([]);
 
         return document.ReplaceNodeAsync(invocationInfo.InvocationExpression, newInvocationExpression, cancellationToken);
     }

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
@@ -580,10 +580,11 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
         in SimpleMemberInvocationExpressionInfo invocationInfo,
         CancellationToken cancellationToken)
     {
-        InvocationExpressionSyntax newInvocationExpression = ChangeInvokedMethodName(invocationInfo.InvocationExpression, "Order")
-            .AddArgumentListArguments([]);
+        InvocationExpressionSyntax newInvocationExpression = ChangeInvokedMethodName(invocationInfo.InvocationExpression, "Order");
 
-        return document.ReplaceNodeAsync(invocationInfo.InvocationExpression, newInvocationExpression, cancellationToken);
+        InvocationExpressionSyntax newerInvocationExpression = newInvocationExpression.RemoveNodes(newInvocationExpression.ArgumentList.Arguments, SyntaxRemoveOptions.KeepExteriorTrivia);
+
+        return document.ReplaceNodeAsync(invocationInfo.InvocationExpression, newerInvocationExpression, cancellationToken);
     }
 
     private static Task<Document> CallOrderByAndWhereInReverseOrderAsync(

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/OptimizeLinqMethodCallCodeFixProvider.cs
@@ -270,6 +270,16 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
                         context.RegisterCodeFix(codeAction, diagnostic);
                         return;
                     }
+                case "OrderBy":
+                    {
+                        CodeAction codeAction = CodeAction.Create(
+                            "Call 'Order()' instead of 'OrderBy(x => x)'",
+                            ct => CallOrderInsteadOfOrderByIdentityAsync(document, invocationInfo, ct),
+                            GetEquivalenceKey(diagnostic, "CallOrderInsteadOfOrderByIdentity"));
+
+                        context.RegisterCodeFix(codeAction, diagnostic);
+                        return;
+                    }
             }
         }
         else if (kind == SyntaxKind.ConditionalExpression)
@@ -561,6 +571,16 @@ public sealed class OptimizeLinqMethodCallCodeFixProvider : BaseCodeFixProvider
         InvocationExpressionSyntax invocationExpression2 = SimpleMemberInvocationExpressionInfo(invocationInfo.Expression).InvocationExpression;
 
         InvocationExpressionSyntax newInvocationExpression = ChangeInvokedMethodName(invocationExpression2, "OrderByDescending");
+
+        return document.ReplaceNodeAsync(invocationInfo.InvocationExpression, newInvocationExpression, cancellationToken);
+    }
+
+    private static Task<Document> CallOrderInsteadOfOrderByIdentityAsync(
+        Document document,
+        in SimpleMemberInvocationExpressionInfo invocationInfo,
+        CancellationToken cancellationToken)
+    {
+        InvocationExpressionSyntax newInvocationExpression = ChangeInvokedMethodName(invocationInfo.InvocationExpression, "Order");
 
         return document.ReplaceNodeAsync(invocationInfo.InvocationExpression, newInvocationExpression, cancellationToken);
     }

--- a/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/InvocationExpressionAnalyzer.cs
@@ -331,6 +331,9 @@ public sealed class InvocationExpressionAnalyzer : BaseDiagnosticAnalyzer
                                 if (DiagnosticRules.CallThenByInsteadOfOrderBy.IsEffective(context))
                                     CallThenByInsteadOfOrderByAnalysis.Analyze(context, invocationInfo);
 
+                                if (DiagnosticRules.OptimizeLinqMethodCall.IsEffective(context))
+                                    OptimizeLinqMethodCallAnalysis.AnalyzeOrderByIdentity(context, invocationInfo);
+
                                 break;
                             }
                     }

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -700,7 +700,7 @@ internal static class OptimizeLinqMethodCallAnalysis
             INamedTypeSymbol containingType = methodSymbol.ContainingType;
             IMethodSymbol orderMethod = containingType.GetMembers("Order")
                 .OfType<IMethodSymbol>()
-                .FirstOrDefault(m => m.Parameters.Length is 1);
+                .FirstOrDefault(member => member.Parameters.Length is 1 && member.Parameters.Single().IsThis);
 
             if (orderMethod is null)
             {

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -695,19 +695,13 @@ internal static class OptimizeLinqMethodCallAnalysis
     {
         InvocationExpressionSyntax invocationExpression = invocationInfo.InvocationExpression;
 
-        if (context.SemanticModel.GetSymbolInfo(invocationExpression).Symbol is IMethodSymbol methodSymbol)
-        {
-            INamedTypeSymbol containingType = methodSymbol.ContainingType;
-            IMethodSymbol orderMethod = containingType.GetMembers("Order")
-                .OfType<IMethodSymbol>()
-                .FirstOrDefault(member => member.Parameters.Length is 1 && member.Parameters.Single().IsThis);
+        IMethodSymbol orderMethod = context.SemanticModel
+            .GetSymbolInfo(invocationExpression)
+            .Symbol.ContainingType
+            .FindMember<IMethodSymbol>(method => method.Name == "Order" && method.Parameters.Length is 1);
 
-            if (orderMethod is null)
-            {
-                // "Order" method does not exist, which happens in older versions of .NET.
-                return;
-            }
-        }
+        if (orderMethod is null)
+            return;
 
         ArgumentSyntax argument = invocationInfo.Arguments.SingleOrDefault(shouldThrow: false);
 

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -700,7 +700,7 @@ internal static class OptimizeLinqMethodCallAnalysis
             INamedTypeSymbol containingType = methodSymbol.ContainingType;
             IMethodSymbol orderMethod = containingType.GetMembers("Order")
                 .OfType<IMethodSymbol>()
-                .FirstOrDefault(m => m.Parameters.Length is 0);
+                .FirstOrDefault(m => m.Parameters.Length is 1);
 
             if (orderMethod is null)
             {

--- a/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/OptimizeLinqMethodCallAnalysis.cs
@@ -697,7 +697,8 @@ internal static class OptimizeLinqMethodCallAnalysis
 
         IMethodSymbol orderMethod = context.SemanticModel
             .GetSymbolInfo(invocationExpression)
-            .Symbol.ContainingType
+            .Symbol
+            .ContainingType
             .FindMember<IMethodSymbol>(method => method.Name == "Order" && method.Parameters.Length is 1);
 
         if (orderMethod is null)

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Roslynator.CSharp.CodeFixes;

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -960,6 +960,38 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
+    public async Task Test_CallOrderInsteadOfOrderByIdentity()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        IEnumerable<object> x = null;
+
+        x = x.[|OrderBy(f => f)|];
+    }
+}
+", @"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        IEnumerable<object> x = null;
+
+        x = x.Order();
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
     public async Task Test_CallOrderByAndWhereInReverseOrder()
     {
         await VerifyDiagnosticAndFixAsync(@"

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -940,7 +940,7 @@ class C
     {
         IEnumerable<object> x = null;
 
-        x = x.[|OrderBy(f => f).Reverse()|];
+        x = x.[|OrderBy(f => { return f; }).Reverse()|];
     }
 }
 ", @"
@@ -953,7 +953,7 @@ class C
     {
         IEnumerable<object> x = null;
 
-        x = x.OrderByDescending(f => f);
+        x = x.OrderByDescending(f => { return f; });
     }
 }
 ");
@@ -1007,7 +1007,7 @@ class C
     {
         IEnumerable<object> x = null;
 
-        x = x.[|OrderBy(f => f).Where(_ => true)|];
+        x = x.[|OrderBy(f => { return f; }).Where(_ => true)|];
     }
 }
 ", @"
@@ -1020,7 +1020,7 @@ class C
     {
         IEnumerable<object> x = null;
 
-        x = x.Where(_ => true).OrderBy(f => f);
+        x = x.Where(_ => true).OrderBy(f => { return f; });
     }
 }
 ");
@@ -1071,7 +1071,7 @@ class C
     {
         IEnumerable<object> x = null;
 
-        x = x.[|OrderByDescending(f => f).Where(_ => true)|];
+        x = x.[|OrderByDescending(f => { return f; }).Where(_ => true)|];
     }
 }
 ", @"
@@ -1084,7 +1084,7 @@ class C
     {
         IEnumerable<object> x = null;
 
-        x = x.Where(_ => true).OrderByDescending(f => f);
+        x = x.Where(_ => true).OrderByDescending(f => { return f; });
     }
 }
 ");

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -962,6 +962,7 @@ class C
     [Theory, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
     [InlineData("OrderBy(f => f)")]
     [InlineData("OrderBy(_ => _)")]
+    [InlineData("OrderBy(@int => @int)")]
     public async Task Test_CallOrderInsteadOfOrderByIdentity(string test)
     {
         await VerifyDiagnosticAndFixAsync($@"

--- a/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1077OptimizeLinqMethodCallTests.cs
@@ -959,27 +959,25 @@ class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
-    public async Task Test_CallOrderInsteadOfOrderByIdentity()
+    [Theory, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]
+    [InlineData("OrderBy(f => f)")]
+    [InlineData("OrderBy(_ => _)")]
+    public async Task Test_CallOrderInsteadOfOrderByIdentity(string test)
     {
-        const string input = @"
+        await VerifyDiagnosticAndFixAsync($@"
 using System.Collections.Generic;
 using System.Linq;
 
 class C
-{
+{{
     void M()
-    {
+    {{
         IEnumerable<object> x = null;
 
-        x = x.[|OrderBy(f => f)|];
-    }
-}
-";
-        // Order() is available in .NET 7 and greater
-        // https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.order?view=net-8.0&viewFallbackFrom=net-6.0
-#if NET7_0_OR_GREATER
-        const string fix = @"
+        x = x.[|{test}|];
+    }}
+}}
+", @"
 using System.Collections.Generic;
 using System.Linq;
 
@@ -992,11 +990,7 @@ class C
         x = x.Order();
     }
 }
-";
-        await VerifyDiagnosticAndFixAsync(input, fix);
-#else
-    await VerifyNoDiagnosticAsync(input);
-#endif
+");
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeLinqMethodCall)]


### PR DESCRIPTION
Fixes #1492 

TODO:
- [x] Unit test fails because the unit test is run with a version of .NET Core where `System.Linq` does not yet implement `IEnumerable<T>.Order()`.

