### PR TITLE
Support duck-typed awaitables and task-like types for Task/Async-related analyzers

### DIFF
--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/DisposeResourceAsynchronouslyCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/DisposeResourceAsynchronouslyCodeFixProvider.cs
@@ -120,7 +120,7 @@ public sealed class DisposeResourceAsynchronouslyCodeFixProvider : BaseCodeFixPr
 
                 IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration, cancellationToken);
 
-                UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
                 var newBody = (BlockSyntax)rewriter.VisitBlock(newNode.Body);
 
                 newNode = newNode
@@ -138,7 +138,7 @@ public sealed class DisposeResourceAsynchronouslyCodeFixProvider : BaseCodeFixPr
 
                 IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(localFunction, cancellationToken);
 
-                UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
                 var newBody = (BlockSyntax)rewriter.VisitBlock(newNode.Body);
 
                 newNode = newNode
@@ -156,7 +156,7 @@ public sealed class DisposeResourceAsynchronouslyCodeFixProvider : BaseCodeFixPr
 
                 var methodSymbol = (IMethodSymbol)semanticModel.GetSymbol(lambdaExpression, cancellationToken);
 
-                UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
                 var newBody = (BlockSyntax)rewriter.VisitBlock((BlockSyntax)newNode.Body);
 
                 newNode = newNode
@@ -174,7 +174,7 @@ public sealed class DisposeResourceAsynchronouslyCodeFixProvider : BaseCodeFixPr
 
                 var methodSymbol = (IMethodSymbol)semanticModel.GetSymbol(anonymousMethod, cancellationToken);
 
-                UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
                 var newBody = (BlockSyntax)rewriter.VisitBlock((BlockSyntax)newNode.Body);
 
                 newNode = newNode

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/UseAsyncAwaitCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/UseAsyncAwaitCodeFixProvider.cs
@@ -66,7 +66,7 @@ public sealed class UseAsyncAwaitCodeFixProvider : BaseCodeFixProvider
                 {
                     IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration, cancellationToken);
 
-                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
 
                     var newNode = (MethodDeclarationSyntax)rewriter.VisitMethodDeclaration(methodDeclaration);
 
@@ -78,7 +78,7 @@ public sealed class UseAsyncAwaitCodeFixProvider : BaseCodeFixProvider
                 {
                     IMethodSymbol methodSymbol = semanticModel.GetDeclaredSymbol(localFunction, cancellationToken);
 
-                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
 
                     var newBody = (BlockSyntax)rewriter.VisitBlock(localFunction.Body);
 
@@ -92,7 +92,7 @@ public sealed class UseAsyncAwaitCodeFixProvider : BaseCodeFixProvider
                 {
                     var methodSymbol = (IMethodSymbol)semanticModel.GetSymbol(lambda, cancellationToken);
 
-                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
 
                     var newBody = (BlockSyntax)rewriter.VisitBlock((BlockSyntax)lambda.Body);
 
@@ -106,7 +106,7 @@ public sealed class UseAsyncAwaitCodeFixProvider : BaseCodeFixProvider
                 {
                     var methodSymbol = (IMethodSymbol)semanticModel.GetSymbol(lambda, cancellationToken);
 
-                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
 
                     var newBody = (BlockSyntax)rewriter.VisitBlock((BlockSyntax)lambda.Body);
 
@@ -120,7 +120,7 @@ public sealed class UseAsyncAwaitCodeFixProvider : BaseCodeFixProvider
                 {
                     var methodSymbol = (IMethodSymbol)semanticModel.GetSymbol(anonymousMethod, cancellationToken);
 
-                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol);
+                    UseAsyncAwaitRewriter rewriter = UseAsyncAwaitRewriter.Create(methodSymbol, semanticModel, node.SpanStart);
 
                     var newBody = (BlockSyntax)rewriter.VisitBlock((BlockSyntax)anonymousMethod.Body);
 

--- a/src/Analyzers.CodeFixes/CSharp/SyntaxRewriters/UseAsyncAwaitRewriter.cs
+++ b/src/Analyzers.CodeFixes/CSharp/SyntaxRewriters/UseAsyncAwaitRewriter.cs
@@ -24,14 +24,14 @@ internal sealed class UseAsyncAwaitRewriter : SkipFunctionRewriter
 
     public bool KeepReturnStatement { get; }
 
-    public static UseAsyncAwaitRewriter Create(IMethodSymbol methodSymbol)
+    public static UseAsyncAwaitRewriter Create(IMethodSymbol methodSymbol, SemanticModel semanticModel, int position)
     {
         ITypeSymbol returnType = methodSymbol.ReturnType.OriginalDefinition;
 
         var keepReturnStatement = false;
 
-        if (returnType.EqualsOrInheritsFrom(MetadataNames.System_Threading_Tasks_ValueTask_T)
-            || returnType.EqualsOrInheritsFrom(MetadataNames.System_Threading_Tasks_Task_T))
+        if (returnType is INamedTypeSymbol { Arity: 1 }
+            && returnType.IsAwaitable(semanticModel, position))
         {
             keepReturnStatement = true;
         }

--- a/src/Analyzers/CSharp/Analysis/ConfigureAwaitAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/ConfigureAwaitAnalyzer.cs
@@ -65,7 +65,7 @@ public sealed class ConfigureAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (typeSymbol is null)
             return;
 
-        if (!SymbolUtility.IsAwaitable(typeSymbol))
+        if (!typeSymbol.IsAwaitable(context.SemanticModel, expression.SpanStart))
             return;
 
         DiagnosticHelpers.ReportDiagnostic(context, DiagnosticRules.ConfigureAwait, awaitExpression.Expression, "Add");

--- a/src/Analyzers/CSharp/Analysis/ConfigureAwaitAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/ConfigureAwaitAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -68,6 +69,9 @@ public sealed class ConfigureAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (!typeSymbol.IsAwaitable(context.SemanticModel, expression.SpanStart))
             return;
 
+        if (!IsConfigureAwaitable(typeSymbol, context.SemanticModel, expression.SpanStart))
+            return;
+
         DiagnosticHelpers.ReportDiagnostic(context, DiagnosticRules.ConfigureAwait, awaitExpression.Expression, "Add");
     }
 
@@ -75,39 +79,43 @@ public sealed class ConfigureAwaitAnalyzer : BaseDiagnosticAnalyzer
     {
         var awaitExpression = (AwaitExpressionSyntax)context.Node;
 
+        // await (expr).ConfigureAwait(false);
+        //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         ExpressionSyntax expression = awaitExpression.Expression;
 
+        // await (expr).ConfigureAwait(false);
+        //             ^^^^^^^^^^^^^^^^^^^^^^
         SimpleMemberInvocationExpressionInfo invocationInfo = SyntaxInfo.SimpleMemberInvocationExpressionInfo(expression);
 
-        if (!IsConfigureAwait(expression))
+        if (!IsConfigureAwait(invocationInfo))
             return;
 
-        ITypeSymbol typeSymbol = context.SemanticModel.GetTypeSymbol(expression, context.CancellationToken);
+        ITypeSymbol awaitedType = context.SemanticModel.GetTypeSymbol(expression, context.CancellationToken);
 
-        if (typeSymbol is null)
+        if (awaitedType is null)
             return;
 
-        switch (typeSymbol.MetadataName)
-        {
-            case "ConfiguredTaskAwaitable":
-            case "ConfiguredTaskAwaitable`1":
-            case "ConfiguredValueTaskAwaitable":
-            case "ConfiguredValueTaskAwaitable`1":
-                {
-                    if (typeSymbol.ContainingNamespace.HasMetadataName(MetadataNames.System_Runtime_CompilerServices))
-                    {
-                        DiagnosticHelpers.ReportDiagnostic(
-                            context,
-                            DiagnosticRules.ConfigureAwait,
-                            Location.Create(
-                                awaitExpression.SyntaxTree,
-                                TextSpan.FromBounds(invocationInfo.OperatorToken.SpanStart, expression.Span.End)),
-                            "Remove");
-                    }
+        if (!awaitedType.IsAwaitable(context.SemanticModel, expression.SpanStart))
+            return;
 
-                    break;
-                }
-        }
+        // await (expr).ConfigureAwait(false);
+        //        ^^^^
+        // This expression may not be awaitable, in which case removing ConfigureAwait is not possible.
+        ITypeSymbol configuredType = context.SemanticModel.GetTypeSymbol(invocationInfo.Expression, context.CancellationToken);
+
+        if (configuredType is null)
+            return;
+
+        if (!configuredType.IsAwaitable(context.SemanticModel, invocationInfo.Expression.SpanStart))
+            return;
+
+        DiagnosticHelpers.ReportDiagnostic(
+            context,
+            DiagnosticRules.ConfigureAwait,
+            Location.Create(
+                awaitExpression.SyntaxTree,
+                TextSpan.FromBounds(invocationInfo.OperatorToken.SpanStart, expression.Span.End)),
+            "Remove");
     }
 
     public static bool IsConfigureAwait(ExpressionSyntax expression)
@@ -123,5 +131,13 @@ public sealed class ConfigureAwaitAnalyzer : BaseDiagnosticAnalyzer
             && invocationInfo.Name.IsKind(SyntaxKind.IdentifierName)
             && string.Equals(invocationInfo.NameText, "ConfigureAwait")
             && invocationInfo.Arguments.Count == 1;
+    }
+
+    private static bool IsConfigureAwaitable(ITypeSymbol typeSymbol, SemanticModel semanticModel, int position)
+    {
+        return semanticModel.LookupSymbols(position, typeSymbol, "ConfigureAwait", includeReducedExtensionMethods: true)
+            .OfType<IMethodSymbol>()
+            .Any(method => method.ReturnType.IsAwaitable(semanticModel, position)
+                && method.HasSingleParameter(SpecialType.System_Boolean));
     }
 }

--- a/src/Analyzers/CSharp/Analysis/DisposeResourceAsynchronouslyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DisposeResourceAsynchronouslyAnalyzer.cs
@@ -131,6 +131,7 @@ public sealed class DisposeResourceAsynchronouslyAnalyzer : BaseDiagnosticAnalyz
                 : context.SemanticModel.GetSymbol(containingMethod, context.CancellationToken)) as IMethodSymbol;
 
             if (methodSymbol?.IsErrorType() == false
+                && methodSymbol.ReturnType.IsTaskType()
                 && methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, context.Node.SpanStart))
             {
                 ReportDiagnostic(context, usingKeyword);

--- a/src/Analyzers/CSharp/Analysis/DisposeResourceAsynchronouslyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DisposeResourceAsynchronouslyAnalyzer.cs
@@ -131,7 +131,7 @@ public sealed class DisposeResourceAsynchronouslyAnalyzer : BaseDiagnosticAnalyz
                 : context.SemanticModel.GetSymbol(containingMethod, context.CancellationToken)) as IMethodSymbol;
 
             if (methodSymbol?.IsErrorType() == false
-                && SymbolUtility.IsAwaitable(methodSymbol.ReturnType))
+                && methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, context.Node.SpanStart))
             {
                 ReportDiagnostic(context, usingKeyword);
             }

--- a/src/Analyzers/CSharp/Analysis/NonAsynchronousMethodNameShouldNotEndWithAsyncAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/NonAsynchronousMethodNameShouldNotEndWithAsyncAnalyzer.cs
@@ -74,7 +74,7 @@ public sealed class AsyncSuffixAnalyzer : BaseDiagnosticAnalyzer
             if (!methodSymbol.Name.EndsWith("Async", StringComparison.Ordinal))
                 return;
 
-            if (SymbolUtility.IsAwaitable(methodSymbol.ReturnType, shouldCheckWindowsRuntimeTypes)
+            if (methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, methodDeclaration.SpanStart)
                 || IsAsyncEnumerableLike(methodSymbol.ReturnType.OriginalDefinition))
             {
                 return;
@@ -105,7 +105,7 @@ public sealed class AsyncSuffixAnalyzer : BaseDiagnosticAnalyzer
             if (methodSymbol.ImplementsInterfaceMember(allInterfaces: true))
                 return;
 
-            if (!SymbolUtility.IsAwaitable(methodSymbol.ReturnType, shouldCheckWindowsRuntimeTypes)
+            if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, methodDeclaration.SpanStart)
                 && !methodSymbol.ReturnType.OriginalDefinition.HasMetadataName(in MetadataNames.System_Collections_Generic_IAsyncEnumerable_T))
             {
                 return;

--- a/src/Analyzers/CSharp/Analysis/RemoveRedundantAsyncAwaitAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/RemoveRedundantAsyncAwaitAnalyzer.cs
@@ -175,7 +175,7 @@ public sealed class RemoveRedundantAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
 
             ITypeSymbol typeSymbol = context.SemanticModel.GetTypeSymbol(expression, context.CancellationToken);
 
-            if (typeSymbol?.OriginalDefinition.HasMetadataName(MetadataNames.System_Runtime_CompilerServices_ConfiguredTaskAwaitable_T) == true
+            if (typeSymbol?.OriginalDefinition.IsAwaitable(context.SemanticModel, expression.SpanStart) == true
                 && (expression is InvocationExpressionSyntax invocation))
             {
                 var memberAccess = invocation.Expression as MemberAccessExpressionSyntax;

--- a/src/Analyzers/CSharp/Analysis/UseAsyncAwaitAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/UseAsyncAwaitAnalyzer.cs
@@ -57,7 +57,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
 
         IMethodSymbol methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodDeclaration, context.CancellationToken);
 
-        if (!SymbolUtility.IsAwaitable(methodSymbol.ReturnType))
+        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, methodDeclaration.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -81,7 +81,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
 
         IMethodSymbol methodSymbol = context.SemanticModel.GetDeclaredSymbol(localFunction, context.CancellationToken);
 
-        if (!SymbolUtility.IsAwaitable(methodSymbol.ReturnType))
+        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, localFunction.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -101,7 +101,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(simpleLambda, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!SymbolUtility.IsAwaitable(methodSymbol.ReturnType))
+        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, simpleLambda.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -121,7 +121,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(parenthesizedLambda, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!SymbolUtility.IsAwaitable(methodSymbol.ReturnType))
+        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, parenthesizedLambda.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -143,7 +143,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(anonymousMethod, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!SymbolUtility.IsAwaitable(methodSymbol.ReturnType))
+        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, anonymousMethod.SpanStart))
             return;
 
         if (IsFixable(body, context))

--- a/src/Analyzers/CSharp/Analysis/UseAsyncAwaitAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/UseAsyncAwaitAnalyzer.cs
@@ -57,7 +57,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
 
         IMethodSymbol methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodDeclaration, context.CancellationToken);
 
-        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, methodDeclaration.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType() || !methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, body.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -81,7 +81,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
 
         IMethodSymbol methodSymbol = context.SemanticModel.GetDeclaredSymbol(localFunction, context.CancellationToken);
 
-        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, localFunction.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType() || !methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, body.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -101,7 +101,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(simpleLambda, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, simpleLambda.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType() || !methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, body.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -121,7 +121,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(parenthesizedLambda, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, parenthesizedLambda.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType() || !methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, body.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -143,7 +143,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(anonymousMethod, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, anonymousMethod.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType() || !methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, body.SpanStart))
             return;
 
         if (IsFixable(body, context))

--- a/src/Analyzers/CSharp/Analysis/UseAsyncAwaitAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/UseAsyncAwaitAnalyzer.cs
@@ -57,7 +57,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
 
         IMethodSymbol methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodDeclaration, context.CancellationToken);
 
-        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, methodDeclaration.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, methodDeclaration.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -81,7 +81,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
 
         IMethodSymbol methodSymbol = context.SemanticModel.GetDeclaredSymbol(localFunction, context.CancellationToken);
 
-        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, localFunction.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, localFunction.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -101,7 +101,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(simpleLambda, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, simpleLambda.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, simpleLambda.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -121,7 +121,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(parenthesizedLambda, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, parenthesizedLambda.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, parenthesizedLambda.SpanStart))
             return;
 
         if (IsFixable(body, context))
@@ -143,7 +143,7 @@ public sealed class UseAsyncAwaitAnalyzer : BaseDiagnosticAnalyzer
         if (context.SemanticModel.GetSymbol(anonymousMethod, context.CancellationToken) is not IMethodSymbol methodSymbol)
             return;
 
-        if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, anonymousMethod.SpanStart))
+        if (!methodSymbol.ReturnType.IsTaskType(context.SemanticModel, anonymousMethod.SpanStart))
             return;
 
         if (IsFixable(body, context))

--- a/src/Common/CSharp/Analysis/RemoveAsyncAwaitAnalysis.cs
+++ b/src/Common/CSharp/Analysis/RemoveAsyncAwaitAnalysis.cs
@@ -364,7 +364,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis : IDisposable
 
         ITypeSymbol returnType = methodSymbol.ReturnType;
 
-        if (returnType?.OriginalDefinition.EqualsOrInheritsFrom(MetadataNames.System_Threading_Tasks_Task_T) != true)
+        if (returnType?.OriginalDefinition.IsAwaitable(semanticModel, node.SpanStart) != true)
             return false;
 
         ITypeSymbol typeArgument = ((INamedTypeSymbol)returnType).TypeArguments.SingleOrDefault(shouldThrow: false);
@@ -394,7 +394,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis : IDisposable
 
         ITypeSymbol returnType = methodSymbol.ReturnType;
 
-        if (returnType?.OriginalDefinition.EqualsOrInheritsFrom(MetadataNames.System_Threading_Tasks_Task_T) != true)
+        if (returnType?.OriginalDefinition.IsAwaitable(semanticModel, node.SpanStart) != true)
             return false;
 
         ITypeSymbol typeArgument = ((INamedTypeSymbol)returnType).TypeArguments.SingleOrDefault(shouldThrow: false);
@@ -417,7 +417,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis : IDisposable
         if (expressionTypeSymbol is null)
             return false;
 
-        if (expressionTypeSymbol.OriginalDefinition.EqualsOrInheritsFrom(MetadataNames.System_Threading_Tasks_Task_T))
+        if (expressionTypeSymbol.OriginalDefinition.IsAwaitable(semanticModel, expression.SpanStart))
             return true;
 
         SimpleMemberInvocationExpressionInfo invocationInfo = SyntaxInfo.SimpleMemberInvocationExpressionInfo(expression);
@@ -425,7 +425,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis : IDisposable
         return invocationInfo.Success
             && invocationInfo.Arguments.Count == 1
             && invocationInfo.NameText == "ConfigureAwait"
-            && expressionTypeSymbol.OriginalDefinition.HasMetadataName(MetadataNames.System_Runtime_CompilerServices_ConfiguredTaskAwaitable_T);
+            && expressionTypeSymbol.OriginalDefinition.IsAwaitable(semanticModel, expression.SpanStart);
     }
 
     private static IMethodSymbol GetMethodSymbol(

--- a/src/Core/MetadataNames.cs
+++ b/src/Core/MetadataNames.cs
@@ -51,6 +51,7 @@ internal static class MetadataNames
     public static readonly MetadataName System_ReadOnlySpan_T = MetadataName.Parse("System.ReadOnlySpan`1");
     public static readonly MetadataName System_Reflection = MetadataName.Parse("System.Reflection");
     public static readonly MetadataName System_Runtime_CompilerServices = MetadataName.Parse("System.Runtime.CompilerServices");
+    public static readonly MetadataName System_Runtime_CompilerServices_AsyncMethodBuilderAttribute = MetadataName.Parse("System.Runtime.CompilerServices.AsyncMethodBuilderAttribute");
     public static readonly MetadataName System_Runtime_CompilerServices_CollectionBuilderAttribute = MetadataName.Parse("System.Runtime.CompilerServices.CollectionBuilderAttribute");
     public static readonly MetadataName System_Runtime_CompilerServices_ConfiguredTaskAwaitable = MetadataName.Parse("System.Runtime.CompilerServices.ConfiguredTaskAwaitable");
     public static readonly MetadataName System_Runtime_CompilerServices_ConfiguredTaskAwaitable_T = MetadataName.Parse("System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1");

--- a/src/Core/MetadataNames.cs
+++ b/src/Core/MetadataNames.cs
@@ -55,6 +55,7 @@ internal static class MetadataNames
     public static readonly MetadataName System_Runtime_CompilerServices_CollectionBuilderAttribute = MetadataName.Parse("System.Runtime.CompilerServices.CollectionBuilderAttribute");
     public static readonly MetadataName System_Runtime_CompilerServices_ConfiguredTaskAwaitable = MetadataName.Parse("System.Runtime.CompilerServices.ConfiguredTaskAwaitable");
     public static readonly MetadataName System_Runtime_CompilerServices_ConfiguredTaskAwaitable_T = MetadataName.Parse("System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1");
+    public static readonly MetadataName System_Runtime_CompilerServices_INotifyCompletion = MetadataName.Parse("System.Runtime.CompilerServices.INotifyCompletion");
     public static readonly MetadataName System_Runtime_InteropServices_LayoutKind = MetadataName.Parse("System.Runtime.InteropServices.LayoutKind");
     public static readonly MetadataName System_Runtime_InteropServices_StructLayoutAttribute = MetadataName.Parse("System.Runtime.InteropServices.StructLayoutAttribute");
     public static readonly MetadataName System_Runtime_Serialization_DataMemberAttribute = MetadataName.Parse("System.Runtime.Serialization.DataMemberAttribute");

--- a/src/Core/SymbolUtility.cs
+++ b/src/Core/SymbolUtility.cs
@@ -713,15 +713,10 @@ internal static class SymbolUtility
     /// <remarks>
     /// For more information, see the <see href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/classes#15151-general">C# language specification</see>.
     /// </remarks>
-    /// <param name="semanticModel">Used to check if the type is awaitable. See <see cref="IsAwaitable(ISymbol?, SemanticModel, int)"/></param>
-    /// <param name="position">Used to check if the type is awaitable. See <see cref="IsAwaitable(ISymbol?, SemanticModel, int)"/></param>
     /// <returns>A <see cref="bool"/> indicating whether the type is a <see href="https://github.com/dotnet/roslyn/blob/main/docs/features/task-types.md">task type</see>.</returns>
-    public static bool IsTaskType(this ITypeSymbol typeSymbol, SemanticModel semanticModel, int position)
+    public static bool IsTaskType(this ITypeSymbol typeSymbol)
     {
         if (typeSymbol.OriginalDefinition is not INamedTypeSymbol definition)
-            return false;
-
-        if (!IsAwaitable(definition, semanticModel, position))
             return false;
 
         // Task (and Task<T>) are hardcoded and don't have an AsyncMethodBuilder attribute.

--- a/src/Tests/Analyzers.Tests/RCS1046AsynchronousMethodNameShouldEndWithAsyncTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1046AsynchronousMethodNameShouldEndWithAsyncTests.cs
@@ -101,6 +101,42 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
+    public async Task Test_DuckTyped()
+    {
+        await VerifyDiagnosticAsync(@"
+class C
+{
+    DuckTyped [|Foo|]() => new();
+    DuckTyped<object> [|Foo2|]() => new();
+}
+
+class DuckTyped
+{
+    public CustomAwaiter GetAwaiter() => new();
+}
+
+class DuckTyped<T>
+{
+    public CustomAwaiter<T> GetAwaiter() => new();
+}
+
+struct CustomAwaiter : System.Runtime.CompilerServices.INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(System.Action continuation) { }
+    public void GetResult() { }
+}
+
+struct CustomAwaiter<T> : System.Runtime.CompilerServices.INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(System.Action continuation) { }
+    public T GetResult() => default(T);
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
     public async Task TestNoDiagnostic_EntryPointMethod()
     {
         await VerifyNoDiagnosticAsync(@"

--- a/src/Tests/Analyzers.Tests/RCS1047NonAsynchronousMethodNameShouldNotEndWithAsyncTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1047NonAsynchronousMethodNameShouldNotEndWithAsyncTests.cs
@@ -133,6 +133,46 @@ class C
     {
         return default(ValueTask);
     }
+    DuckTyped DuckTypedAsync()
+    {
+        return default(DuckTyped);
+    }
+    DuckTyped<object> DuckTypedGenericAsync()
+    {
+        return default(DuckTyped<object>);
+    }
+    T DuckTypedAsync<T>() where T : DuckTyped
+    {
+        return default(T);
+    }
+    T DuckTypedGenericAsync<T>() where T : DuckTyped<object>
+    {
+        return default(T);
+    }
+}
+
+class DuckTyped
+{
+    public CustomAwaiter GetAwaiter() => new();
+}
+
+class DuckTyped<T>
+{
+    public CustomAwaiter<T> GetAwaiter() => new();
+}
+
+struct CustomAwaiter : System.Runtime.CompilerServices.INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(System.Action continuation) { }
+    public void GetResult() { }
+}
+
+struct CustomAwaiter<T> : System.Runtime.CompilerServices.INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(System.Action continuation) { }
+    public T GetResult() => default(T);
 }
 ");
     }

--- a/src/Tests/Analyzers.Tests/RCS1090RemoveCallToConfigureAwaitTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1090RemoveCallToConfigureAwaitTests.cs
@@ -246,6 +246,168 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ConfigureAwait)]
+    public async Task Test_DuckTyped()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    async Task M()
+    {
+        await M2()[|.ConfigureAwait(false)|];
+    }
+    DuckTyped M2() => default(DuckTyped);
+}
+
+class DuckTyped
+{
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => false;
+        public void OnCompleted(System.Action continuation) { }
+        public void GetResult() { }
+    }
+
+    public ConfiguredDuckTyped ConfigureAwait(bool continueOnCapturedContext)
+    {
+        return default(ConfiguredDuckTyped);
+    }
+    public struct ConfiguredDuckTyped
+    {
+        public ConfiguredDuckAwaiter GetAwaiter() => default(ConfiguredDuckAwaiter);
+
+        public struct ConfiguredDuckAwaiter : INotifyCompletion
+        {
+            public bool IsCompleted => false;
+            public void OnCompleted(System.Action continuation) { }
+            public void GetResult() { }
+        }
+    }
+}
+", @"
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    async Task M()
+    {
+        await M2();
+    }
+    DuckTyped M2() => default(DuckTyped);
+}
+
+class DuckTyped
+{
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => false;
+        public void OnCompleted(System.Action continuation) { }
+        public void GetResult() { }
+    }
+
+    public ConfiguredDuckTyped ConfigureAwait(bool continueOnCapturedContext)
+    {
+        return default(ConfiguredDuckTyped);
+    }
+    public struct ConfiguredDuckTyped
+    {
+        public ConfiguredDuckAwaiter GetAwaiter() => default(ConfiguredDuckAwaiter);
+
+        public struct ConfiguredDuckAwaiter : INotifyCompletion
+        {
+            public bool IsCompleted => false;
+            public void OnCompleted(System.Action continuation) { }
+            public void GetResult() { }
+        }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ConfigureAwait)]
+    public async Task Test_ExtensionMethod()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    async Task M()
+    {
+        await Task.Yield()[|.ConfigureAwait(false)|];
+    }
+}
+
+static class E
+{
+    public static ConfiguredYieldAwaitable ConfigureAwait(this YieldAwaitable yieldAwaitable, bool continueOnCapturedContext)
+    {
+        return default(ConfiguredYieldAwaitable);
+    }
+}
+
+struct ConfiguredYieldAwaitable
+{
+    public ConfiguredYieldAwaitable(YieldAwaitable yieldAwaitable, bool continueOnCapturedContext)
+    {
+    }
+
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => false;
+        public void OnCompleted(System.Action continuation) { }
+        public void GetResult() { }
+    }
+}
+", @"
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    async Task M()
+    {
+        await Task.Yield();
+    }
+}
+
+static class E
+{
+    public static ConfiguredYieldAwaitable ConfigureAwait(this YieldAwaitable yieldAwaitable, bool continueOnCapturedContext)
+    {
+        return default(ConfiguredYieldAwaitable);
+    }
+}
+
+struct ConfiguredYieldAwaitable
+{
+    public ConfiguredYieldAwaitable(YieldAwaitable yieldAwaitable, bool continueOnCapturedContext)
+    {
+    }
+
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => false;
+        public void OnCompleted(System.Action continuation) { }
+        public void GetResult() { }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ConfigureAwait)]
     public async Task TestNoDiagnostic_Task()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -309,6 +471,87 @@ class C
     }
 
     ValueTask<object> M2() => default;
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ConfigureAwait)]
+    public async Task TestNoDiagnostic_ExtensionMethod()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    async Task M()
+    {
+        await Task.Yield();
+    }
+}
+
+static class E
+{
+    public static ConfiguredYieldAwaitable ConfigureAwait(this YieldAwaitable yieldAwaitable, bool continueOnCapturedContext)
+    {
+        return default(ConfiguredYieldAwaitable);
+    }
+}
+
+struct ConfiguredYieldAwaitable
+{
+    public ConfiguredYieldAwaitable(YieldAwaitable yieldAwaitable, bool continueOnCapturedContext)
+    {
+    }
+
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => false;
+        public void OnCompleted(System.Action continuation) { }
+        public void GetResult() { }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ConfigureAwait)]
+    public async Task TestNoDiagnostic_NonAwaitable_Lookalike()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    async Task M()
+    {
+        await M2().ConfigureAwait(false);
+    }
+    NonAwaitable M2() => default;
+}
+
+struct Awaitable
+{
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => false;
+        public void OnCompleted(System.Action continuation) { }
+        public void GetResult() { }
+    }
+}
+
+struct NonAwaitable
+{
+    // no awaiter
+
+    public Awaitable ConfigureAwait(bool continueOnCapturedContext)
+    {
+        return default(Awaitable);
+    }
 }
 ");
     }

--- a/src/Tests/Analyzers.Tests/RCS1229UseAsyncAwaitTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1229UseAsyncAwaitTests.cs
@@ -452,7 +452,73 @@ class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UnusedElementInDocumentationComment)]
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
+    public async Task Test_DuckTyped_TaskType()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    DuckTyped [|M|]()
+    {
+        using (default(IDisposable))
+        {
+            return GetAsync();
+        }
+    }
+
+    DuckTyped GetAsync() => default;
+}
+
+[AsyncMethodBuilder(null)]
+class DuckTyped
+{
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => true;
+        public void OnCompleted(Action continuation) { }
+        public void GetResult() { }
+    }
+}
+", @"
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    async DuckTyped M()
+    {
+        using (default(IDisposable))
+        {
+            await GetAsync();
+        }
+    }
+
+    DuckTyped GetAsync() => default;
+}
+
+[AsyncMethodBuilder(null)]
+class DuckTyped
+{
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => true;
+        public void OnCompleted(Action continuation) { }
+        public void GetResult() { }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
     public async Task TestNoDiagnostic_UsingLocalDeclaration()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -477,7 +543,7 @@ public class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UnusedElementInDocumentationComment)]
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
     public async Task TestNoDiagnostic_TaskCompletedTask()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -496,7 +562,7 @@ class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UnusedElementInDocumentationComment)]
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
     public async Task TestNoDiagnostic_TaskFromCanceled()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -515,7 +581,7 @@ class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UnusedElementInDocumentationComment)]
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
     public async Task TestNoDiagnostic_TaskFromException()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -534,7 +600,7 @@ class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UnusedElementInDocumentationComment)]
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
     public async Task TestNoDiagnostic_TaskOfTFromResult()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -553,7 +619,7 @@ class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UnusedElementInDocumentationComment)]
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
     public async Task TestNoDiagnostic_TaskOfTFromCanceled()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -572,7 +638,7 @@ class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UnusedElementInDocumentationComment)]
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
     public async Task TestNoDiagnostic_TaskOfTFromException()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -591,7 +657,7 @@ class C
 ");
     }
 
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UnusedElementInDocumentationComment)]
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
     public async Task TestNoDiagnostic_IAsyncEnumerable()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -613,6 +679,42 @@ class C
     {
         await System.Threading.Tasks.Task.CompletedTask;
         yield break;
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
+    public async Task TestNoDiagnostic_DuckTyped_NotTaskType()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    DuckTyped M()
+    {
+        using (default(IDisposable))
+        {
+            return GetAsync();
+        }
+    }
+
+    DuckTyped GetAsync() => default;
+}
+
+//[AsyncMethodBuilder(null)]
+class DuckTyped
+{
+    public Awaiter GetAwaiter() => default(Awaiter);
+
+    public struct Awaiter : INotifyCompletion
+    {
+        public bool IsCompleted => true;
+        public void OnCompleted(Action continuation) { }
+        public void GetResult() { }
     }
 }
 ");

--- a/src/Tests/Analyzers.Tests/RCS1229UseAsyncAwaitTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1229UseAsyncAwaitTests.cs
@@ -470,20 +470,39 @@ class C
         }
     }
 
+    DuckTyped<int> [|M2|]()
+    {
+        using (default(IDisposable))
+        {
+            return GetAsync<int>();
+        }
+    }
+
     DuckTyped GetAsync() => default;
+    DuckTyped<T> GetAsync<T>() => default;
 }
 
 [AsyncMethodBuilder(null)]
 class DuckTyped
 {
     public Awaiter GetAwaiter() => default(Awaiter);
-
-    public struct Awaiter : INotifyCompletion
-    {
-        public bool IsCompleted => true;
-        public void OnCompleted(Action continuation) { }
-        public void GetResult() { }
-    }
+}
+[AsyncMethodBuilder(null)]
+class DuckTyped<T>
+{
+    public Awaiter<T> GetAwaiter() => default(Awaiter<T>);
+}
+public struct Awaiter : INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(Action continuation) { }
+    public void GetResult() { }
+}
+public struct Awaiter<T> : INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(Action continuation) { }
+    public T GetResult() => default(T);
 }
 ", @"
 using System;
@@ -500,20 +519,39 @@ class C
         }
     }
 
+    async DuckTyped<int> M2()
+    {
+        using (default(IDisposable))
+        {
+            return await GetAsync<int>();
+        }
+    }
+
     DuckTyped GetAsync() => default;
+    DuckTyped<T> GetAsync<T>() => default;
 }
 
 [AsyncMethodBuilder(null)]
 class DuckTyped
 {
     public Awaiter GetAwaiter() => default(Awaiter);
-
-    public struct Awaiter : INotifyCompletion
-    {
-        public bool IsCompleted => true;
-        public void OnCompleted(Action continuation) { }
-        public void GetResult() { }
-    }
+}
+[AsyncMethodBuilder(null)]
+class DuckTyped<T>
+{
+    public Awaiter<T> GetAwaiter() => default(Awaiter<T>);
+}
+public struct Awaiter : INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(Action continuation) { }
+    public void GetResult() { }
+}
+public struct Awaiter<T> : INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(Action continuation) { }
+    public T GetResult() => default(T);
 }
 ");
     }
@@ -689,7 +727,6 @@ class C
     {
         await VerifyNoDiagnosticAsync(@"
 using System;
-using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 
 class C
@@ -702,21 +739,76 @@ class C
         }
     }
 
+    DuckTyped<int> M2()
+    {
+        using (default(IDisposable))
+        {
+            return GetAsync<int>();
+        }
+    }
+
     DuckTyped GetAsync() => default;
+    DuckTyped<T> GetAsync<T>() => default;
 }
 
 //[AsyncMethodBuilder(null)]
 class DuckTyped
 {
     public Awaiter GetAwaiter() => default(Awaiter);
-
-    public struct Awaiter : INotifyCompletion
-    {
-        public bool IsCompleted => true;
-        public void OnCompleted(Action continuation) { }
-        public void GetResult() { }
-    }
 }
+//[AsyncMethodBuilder(null)]
+class DuckTyped<T>
+{
+    public Awaiter<T> GetAwaiter() => default(Awaiter<T>);
+}
+
+public struct Awaiter : INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(Action continuation) { }
+    public void GetResult() { }
+}
+public struct Awaiter<T> : INotifyCompletion
+{
+    public bool IsCompleted => true;
+    public void OnCompleted(Action continuation) { }
+    public T GetResult() => default(T);
+}
+");
+    }
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseAsyncAwait)]
+    public async Task TestNoDiagnostic_NonAwaitable_TaskType()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    NonAwaitableTaskType M()
+    {
+        using (default(IDisposable))
+        {
+            return GetAsync();
+        }
+    }
+
+    NonAwaitableTaskType<int> M2()
+    {
+        using (default(IDisposable))
+        {
+            return GetAsync<int>();
+        }
+    }
+
+    NonAwaitableTaskType GetAsync() => default;
+    NonAwaitableTaskType<T> GetAsync<T>() => default;
+}
+
+[AsyncMethodBuilder(null)]
+class NonAwaitableTaskType { }
+[AsyncMethodBuilder(null)]
+class NonAwaitableTaskType<T> { }
 ");
     }
 }


### PR DESCRIPTION
### Description
These changes add the same logic for checking [duck-typed awaitables](https://github.com/dotnet/roslyn/blob/7b7951aa13c50ad768538e58ed3805898b058928/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs#L577-L639) and [task-like types](https://github.com/dotnet/roslyn/blob/c4203b867e9c0287cabb0a0674bfca096c08fd3e/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs#L1778) that is currently in Roslyn.

This resolves #1529 - specifically, these analyzers/refactorings become aware of custom awaitables/custom task-like types:
- RCS1046/RCS1047 (async/sync method name should/should not end in `Async`)
- RCS1090 (use/remove `ConfigureAwait(false)`)
- RCS1229/RCS1174 (use/remove `async`/`await`)
- RCS1261 (dispose asynchronously)
- RR0209 (remove `async`/`await`)

### Remarks
RCS1090's behaviour is less obvious here - it seems there is no official stance for duck-typing `ConfigureAwait` (even [Roslyn](https://github.com/dotnet/roslyn/blob/149c24c648c2211ca580539d43dc97e118b80658/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs#L71) isn't [perfectly consistent](https://github.com/dotnet/roslyn/blob/149c24c648c2211ca580539d43dc97e118b80658/src/Compilers/Core/Portable/InternalUtilities/YieldAwaitableExtensions.cs#L19)), but I'm of the opinion that if the rest of the ducks are quacking, it's better to join the flock 😄 The result is that these checks are relaxed from the `Task`-specific ``ConfiguredTaskAwaitable(`1)`` return type to any awaitable return type.

I noticed there were some checks for [WinRT async interfaces](https://github.com/dotnet/roslynator/blob/df7ec0ec6ad693b10f14cc5ccd272e63b14f8016/src/Core/SymbolUtility.cs#L653), these are covered as there's an [extension `GetAwaiter()` method](https://learn.microsoft.com/en-us/dotnet/api/system.windowsruntimesystemextensions.getawaiter?view=dotnet-uwp-10.0#overloads) available on those types.

I'm not experienced with analyzers and their edge cases so it's possible I've missed writing some obvious tests, I'd love to get your feedback.