### PR TITLE
Add support for GitLab output format in AnalyzeCommand

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.14.0] - 2025-04-07
+
+- [CLI] Add support for GitLab analyzer reports ([PR](https://github.com/dotnet/roslynator/pull/1633))
+
 ## [4.13.1] - 2025-02-23
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.14.0] - 2025-04-07
+### Added
 
 - [CLI] Add support for GitLab analyzer reports ([PR](https://github.com/dotnet/roslynator/pull/1633))
 

--- a/src/CommandLine/Commands/AnalyzeCommand.cs
+++ b/src/CommandLine/Commands/AnalyzeCommand.cs
@@ -97,7 +97,7 @@ internal class AnalyzeCommand : MSBuildWorkspaceCommand<AnalyzeCommandResult>
             && analysisResults.Any(f => f.Diagnostics.Any() || f.CompilerDiagnostics.Any()))
         {
             CultureInfo culture = (Options.Culture is not null) ? CultureInfo.GetCultureInfo(Options.Culture) : null;
-            if (Options.OutputFormat == "gitlab")
+            if (!string.IsNullOrWhiteSpace(Options.OutputFormat) && Options.OutputFormat.Equals("gitlab", StringComparison.CurrentCultureIgnoreCase))
             {
                 DiagnosticGitLabJsonSerializer.Serialize(analysisResults, Options.Output, culture);
             }

--- a/src/CommandLine/Commands/AnalyzeCommand.cs
+++ b/src/CommandLine/Commands/AnalyzeCommand.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Roslynator.CommandLine.Json;
 using Roslynator.CommandLine.Xml;
 using Roslynator.Diagnostics;
 using static Roslynator.Logger;
@@ -96,8 +97,15 @@ internal class AnalyzeCommand : MSBuildWorkspaceCommand<AnalyzeCommandResult>
             && analysisResults.Any(f => f.Diagnostics.Any() || f.CompilerDiagnostics.Any()))
         {
             CultureInfo culture = (Options.Culture is not null) ? CultureInfo.GetCultureInfo(Options.Culture) : null;
-
-            DiagnosticXmlSerializer.Serialize(analysisResults, Options.Output, culture);
+            if (Options.OutputFormat == "gitlab")
+            {
+                DiagnosticGitLabJsonSerializer.Serialize(analysisResults, Options.Output, culture);
+            }
+            else
+            {
+                // Default output format is xml
+                DiagnosticXmlSerializer.Serialize(analysisResults, Options.Output, culture);
+            }
         }
     }
 

--- a/src/CommandLine/GitLab/GitLabIssue.cs
+++ b/src/CommandLine/GitLab/GitLabIssue.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Roslynator.CommandLine.GitLab
+{
+    internal sealed class GitLabIssue
+    {
+        public string Type { get; set; }
+        public string Fingerprint { get; set; }
+        [JsonProperty("check_name")]
+        public string CheckName { get; set; }
+        public string Description { get; set; }
+        public string Severity { get; set; }
+        public GitLabIssueLocation Location { get; set; }
+        public string[] Categories { get; set; }
+    }
+}

--- a/src/CommandLine/GitLab/GitLabIssue.cs
+++ b/src/CommandLine/GitLab/GitLabIssue.cs
@@ -1,16 +1,15 @@
 using Newtonsoft.Json;
 
-namespace Roslynator.CommandLine.GitLab
+namespace Roslynator.CommandLine.GitLab;
+
+internal sealed class GitLabIssue
 {
-    internal sealed class GitLabIssue
-    {
-        public string Type { get; set; }
-        public string Fingerprint { get; set; }
-        [JsonProperty("check_name")]
-        public string CheckName { get; set; }
-        public string Description { get; set; }
-        public string Severity { get; set; }
-        public GitLabIssueLocation Location { get; set; }
-        public string[] Categories { get; set; }
-    }
+    public string Type { get; set; }
+    public string Fingerprint { get; set; }
+    [JsonProperty("check_name")]
+    public string CheckName { get; set; }
+    public string Description { get; set; }
+    public string Severity { get; set; }
+    public GitLabIssueLocation Location { get; set; }
+    public string[] Categories { get; set; }
 }

--- a/src/CommandLine/GitLab/GitLabIssueLocation.cs
+++ b/src/CommandLine/GitLab/GitLabIssueLocation.cs
@@ -1,0 +1,8 @@
+namespace Roslynator.CommandLine.GitLab
+{
+    internal sealed class GitLabIssueLocation
+    {
+        public string Path { get; set; }
+        public GitLabLocationLines Lines { get; set; }
+    }
+}

--- a/src/CommandLine/GitLab/GitLabIssueLocation.cs
+++ b/src/CommandLine/GitLab/GitLabIssueLocation.cs
@@ -1,8 +1,7 @@
-namespace Roslynator.CommandLine.GitLab
+namespace Roslynator.CommandLine.GitLab;
+
+internal sealed class GitLabIssueLocation
 {
-    internal sealed class GitLabIssueLocation
-    {
-        public string Path { get; set; }
-        public GitLabLocationLines Lines { get; set; }
-    }
+    public string Path { get; set; }
+    public GitLabLocationLines Lines { get; set; }
 }

--- a/src/CommandLine/GitLab/GitLabLocationLines.cs
+++ b/src/CommandLine/GitLab/GitLabLocationLines.cs
@@ -1,7 +1,6 @@
-namespace Roslynator.CommandLine.GitLab
+namespace Roslynator.CommandLine.GitLab;
+
+internal sealed class GitLabLocationLines
 {
-    internal sealed class GitLabLocationLines
-    {
-        public int Begin { get; set; }
-    }
+    public int Begin { get; set; }
 }

--- a/src/CommandLine/GitLab/GitLabLocationLines.cs
+++ b/src/CommandLine/GitLab/GitLabLocationLines.cs
@@ -1,0 +1,7 @@
+namespace Roslynator.CommandLine.GitLab
+{
+    internal sealed class GitLabLocationLines
+    {
+        public int Begin { get; set; }
+    }
+}

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -69,7 +69,7 @@ internal static class DiagnosticGitLabJsonSerializer
                 Description = diagnostic.Descriptor.Title.ToString(formatProvider),
                 Severity = severity,
                 Location = location,
-                Categories = [diagnostic.Descriptor.Category],
+                Categories = new string[] { diagnostic.Descriptor.Category },
             });
         }
 

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -14,6 +14,16 @@ namespace Roslynator.CommandLine.Json;
 
 internal static class DiagnosticGitLabJsonSerializer
 {
+    private static readonly JsonSerializerSettings _jsonSerializerSettings = new()
+    {
+        Formatting = Newtonsoft.Json.Formatting.Indented,
+        NullValueHandling = NullValueHandling.Ignore,
+        ContractResolver = new DefaultContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy()
+        },
+    };
+
     public static void Serialize(
         IEnumerable<ProjectAnalysisResult> results,
         string filePath,
@@ -63,17 +73,7 @@ internal static class DiagnosticGitLabJsonSerializer
             });
         }
 
-        string report = JsonConvert.SerializeObject(
-            reportItems,
-            new JsonSerializerSettings()
-            {
-                Formatting = Newtonsoft.Json.Formatting.Indented,
-                NullValueHandling = NullValueHandling.Ignore,
-                ContractResolver = new DefaultContractResolver()
-                {
-                    NamingStrategy = new CamelCaseNamingStrategy()
-                },
-            });
+        string report = JsonConvert.SerializeObject(reportItems, _jsonSerializerSettings);
 
         File.WriteAllText(filePath, report, Encoding.UTF8);
     }

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -69,7 +69,7 @@ internal static class DiagnosticGitLabJsonSerializer
             });
         }
 
-        string gitlabreport = JsonConvert.SerializeObject(
+        string report = JsonConvert.SerializeObject(
             reportItems,
             new JsonSerializerSettings()
             {
@@ -81,6 +81,6 @@ internal static class DiagnosticGitLabJsonSerializer
                 },
             });
 
-        File.WriteAllText(filePath, gitlabreport, Encoding.UTF8);
+        File.WriteAllText(filePath, report, Encoding.UTF8);
     }
 }

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -38,18 +38,12 @@ internal static class DiagnosticGitLabJsonSerializer
             }
 
             var severity = "minor";
-            switch (diagnostic.Severity)
+            severity = diagnostic.Severity switch
             {
-                case DiagnosticSeverity.Warning:
-                    severity = "major";
-                    break;
-                case DiagnosticSeverity.Error:
-                    severity = "critical";
-                    break;
-                default:
-                    severity = "minor";
-                    break;
-            }
+                DiagnosticSeverity.Warning => "major",
+                DiagnosticSeverity.Error => "critical",
+                _ => "minor",
+            };
 
             string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
             byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(issueFingerPrint));
@@ -65,7 +59,7 @@ internal static class DiagnosticGitLabJsonSerializer
                 Description = diagnostic.Descriptor.Title.ToString(formatProvider),
                 Severity = severity,
                 Location = location,
-                Categories = new string[] { diagnostic.Descriptor.Category },
+                Categories = [diagnostic.Descriptor.Category],
             });
         }
 

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -7,8 +7,8 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using Roslynator.Diagnostics;
 using Roslynator.CommandLine.GitLab;
+using Roslynator.Diagnostics;
 
 namespace Roslynator.CommandLine.Json;
 

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -56,7 +56,14 @@ internal static class DiagnosticGitLabJsonSerializer
             };
 
             string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
-            byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(issueFingerPrint));
+            byte[] source = Encoding.UTF8.GetBytes(issueFingerPrint);
+            byte[] hashBytes;
+#if NETFRAMEWORK
+            using (var sha256 = SHA256.Create())
+                hashBytes = sha256.ComputeHash(source);
+#else
+            hashBytes = SHA256.HashData(source);
+#endif
             issueFingerPrint = BitConverter.ToString(hashBytes)
                 .Replace("-", "")
                 .ToLowerInvariant();

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -2,84 +2,85 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Roslynator.Diagnostics;
 using Roslynator.CommandLine.GitLab;
-using System.Security.Cryptography;
 
-namespace Roslynator.CommandLine.Json
+namespace Roslynator.CommandLine.Json;
+
+internal static class DiagnosticGitLabJsonSerializer
 {
-    internal static class DiagnosticGitLabJsonSerializer
+    public static void Serialize(
+        IEnumerable<ProjectAnalysisResult> results,
+        string filePath,
+        IFormatProvider formatProvider = null)
     {
-        public static void Serialize(
-            IEnumerable<ProjectAnalysisResult> results,
-            string filePath,
-            IFormatProvider formatProvider = null)
+        IEnumerable<DiagnosticInfo> diagnostics = results.SelectMany(f => f.CompilerDiagnostics.Concat(f.Diagnostics));
+
+        var reportItems = new List<GitLabIssue>();
+        foreach (DiagnosticInfo diagnostic in diagnostics)
         {
-            var diagnostics = results.SelectMany(f => f.CompilerDiagnostics.Concat(f.Diagnostics));
-
-            var reportItems = new List<GitLabIssue>();
-            foreach (var diagnostic in diagnostics)
+            GitLabIssueLocation location = null;
+            if (diagnostic.LineSpan.IsValid)
             {
-                GitLabIssueLocation location = null;
-                if (diagnostic.LineSpan.IsValid)
+                location = new GitLabIssueLocation()
                 {
-                    location = new GitLabIssueLocation
+                    Path = diagnostic.LineSpan.Path,
+                    Lines = new GitLabLocationLines()
                     {
-                        Path = diagnostic.LineSpan.Path,
-                        Lines = new GitLabLocationLines
-                        {
-                            Begin = diagnostic.LineSpan.StartLinePosition.Line
-                        }
-                    };
-                }
-
-                string severity = "minor";
-                switch (diagnostic.Severity)
-                {
-                    case DiagnosticSeverity.Warning:
-                        severity = "major";
-                        break;
-                    case DiagnosticSeverity.Error:
-                        severity = "critical";
-                        break;
-                    default:
-                        severity = "minor";
-                        break;
-                }
-
-                string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
-                byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(issueFingerPrint));
-                issueFingerPrint = BitConverter.ToString(hashBytes)
-                    .Replace("-", "")
-                    .ToLowerInvariant();
-
-                reportItems.Add(new GitLabIssue
-                {
-                    Type = "issue",
-                    Fingerprint = issueFingerPrint,
-                    CheckName = diagnostic.Descriptor.Id,
-                    Description = diagnostic.Descriptor.Title.ToString(formatProvider),
-                    Severity = severity,
-                    Location = location,
-                    Categories = [diagnostic.Descriptor.Category]
-                });
+                        Begin = diagnostic.LineSpan.StartLinePosition.Line
+                    },
+                };
             }
 
-            var gitlabreport = JsonConvert.SerializeObject(reportItems, new JsonSerializerSettings
+            var severity = "minor";
+            switch (diagnostic.Severity)
+            {
+                case DiagnosticSeverity.Warning:
+                    severity = "major";
+                    break;
+                case DiagnosticSeverity.Error:
+                    severity = "critical";
+                    break;
+                default:
+                    severity = "minor";
+                    break;
+            }
+
+            string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
+            byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(issueFingerPrint));
+            issueFingerPrint = BitConverter.ToString(hashBytes)
+                .Replace("-", "")
+                .ToLowerInvariant();
+
+            reportItems.Add(new GitLabIssue()
+            {
+                Type = "issue",
+                Fingerprint = issueFingerPrint,
+                CheckName = diagnostic.Descriptor.Id,
+                Description = diagnostic.Descriptor.Title.ToString(formatProvider),
+                Severity = severity,
+                Location = location,
+                Categories = new string[] { diagnostic.Descriptor.Category },
+            });
+        }
+
+        string gitlabreport = JsonConvert.SerializeObject(
+            reportItems,
+            new JsonSerializerSettings()
             {
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 NullValueHandling = NullValueHandling.Ignore,
-                ContractResolver = new DefaultContractResolver
+                ContractResolver = new DefaultContractResolver()
                 {
                     NamingStrategy = new CamelCaseNamingStrategy()
-                }
+                },
             });
 
-            File.WriteAllText(filePath, gitlabreport, Encoding.UTF8);
-        }
+        File.WriteAllText(filePath, gitlabreport, Encoding.UTF8);
     }
 }

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Roslynator.Diagnostics;
+using Roslynator.CommandLine.GitLab;
+using System.Security.Cryptography;
+
+namespace Roslynator.CommandLine.Json
+{
+    internal static class DiagnosticGitLabJsonSerializer
+    {
+        public static void Serialize(
+            IEnumerable<ProjectAnalysisResult> results,
+            string filePath,
+            IFormatProvider formatProvider = null)
+        {
+            var diagnostics = results.SelectMany(f => f.CompilerDiagnostics.Concat(f.Diagnostics));
+
+            var reportItems = new List<GitLabIssue>();
+            foreach (var diagnostic in diagnostics)
+            {
+                GitLabIssueLocation location = null;
+                if (diagnostic.LineSpan.IsValid)
+                {
+                    location = new GitLabIssueLocation
+                    {
+                        Path = diagnostic.LineSpan.Path,
+                        Lines = new GitLabLocationLines
+                        {
+                            Begin = diagnostic.LineSpan.StartLinePosition.Line
+                        }
+                    };
+                }
+
+                string severity = "minor";
+                switch (diagnostic.Severity)
+                {
+                    case DiagnosticSeverity.Warning:
+                        severity = "major";
+                        break;
+                    case DiagnosticSeverity.Error:
+                        severity = "critical";
+                        break;
+                    default:
+                        severity = "minor";
+                        break;
+                }
+
+                string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
+                byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(issueFingerPrint));
+                issueFingerPrint = BitConverter.ToString(hashBytes)
+                    .Replace("-", "")
+                    .ToLowerInvariant();
+
+                reportItems.Add(new GitLabIssue
+                {
+                    Type = "issue",
+                    Fingerprint = issueFingerPrint,
+                    CheckName = diagnostic.Descriptor.Id,
+                    Description = diagnostic.Descriptor.Title.ToString(formatProvider),
+                    Severity = severity,
+                    Location = location,
+                    Categories = [diagnostic.Descriptor.Category]
+                });
+            }
+
+            var gitlabreport = JsonConvert.SerializeObject(reportItems, new JsonSerializerSettings
+            {
+                Formatting = Newtonsoft.Json.Formatting.Indented,
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new DefaultContractResolver
+                {
+                    NamingStrategy = new CamelCaseNamingStrategy()
+                }
+            });
+
+            File.WriteAllText(filePath, gitlabreport, Encoding.UTF8);
+        }
+    }
+}

--- a/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
+++ b/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
@@ -26,7 +26,7 @@ public class AnalyzeCommandLineOptions : AbstractAnalyzeCommandLineOptions
 
     [Option(
         longName: "output-format",
-        HelpText = "Defines file format of the report written to file. If not specified, xml will be used.")]
+        HelpText = "Defines file format of the report written to file. Supported options are: xml and gitlab, with xml the default if not provided.")]
     public string OutputFormat { get; set; }
 
     [Option(

--- a/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
+++ b/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
@@ -26,7 +26,7 @@ public class AnalyzeCommandLineOptions : AbstractAnalyzeCommandLineOptions
 
     [Option(
         longName: "output-format",
-        HelpText = "Defines file format of the report written to file. Supported options are: xml and gitlab, with xml the default if not provided.")]
+        HelpText = "Defines the file format of the report written to file. Supported options are: gitlab and xml, with xml the default if no option is provided.")]
     public string OutputFormat { get; set; }
 
     [Option(

--- a/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
+++ b/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
@@ -20,9 +20,14 @@ public class AnalyzeCommandLineOptions : AbstractAnalyzeCommandLineOptions
     [Option(
         shortName: OptionShortNames.Output,
         longName: "output",
-        HelpText = "Defines path to file that will store reported diagnostics in XML format.",
+        HelpText = "Defines path to file that will store reported diagnostics. The format of the file is determined by the --output-format option, with the default being xml.",
         MetaValue = "<FILE_PATH>")]
     public string Output { get; set; }
+
+    [Option(
+        longName: "output-format",
+        HelpText = "Defines file format of the report written to file. If not specified, xml will be used.")]
+    public string OutputFormat { get; set; }
 
     [Option(
         longName: "report-not-configurable",

--- a/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
+++ b/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
@@ -39,8 +39,8 @@ public class AnalyzeCommandLineOptions : AbstractAnalyzeCommandLineOptions
         HelpText = "Indicates whether suppressed diagnostics should be reported.")]
     public bool ReportSuppressedDiagnostics { get; set; }
 
-    internal bool TryParseOutputFormat(string defaultValue)
+    internal bool ValidateOutputFormat()
     {
-        return ParseHelpers.TryParseOutputFormat(OutputFormat, defaultValue);
+        return ParseHelpers.TryParseOutputFormat(OutputFormat);
     }
 }

--- a/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
+++ b/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
@@ -38,4 +38,9 @@ public class AnalyzeCommandLineOptions : AbstractAnalyzeCommandLineOptions
         longName: "report-suppressed-diagnostics",
         HelpText = "Indicates whether suppressed diagnostics should be reported.")]
     public bool ReportSuppressedDiagnostics { get; set; }
+
+    internal bool TryParseOutputFormat(string defaultValue)
+    {
+        return ParseHelpers.TryParseOutputFormat(OutputFormat, defaultValue);
+    }
 }

--- a/src/CommandLine/ParseHelpers.cs
+++ b/src/CommandLine/ParseHelpers.cs
@@ -349,4 +349,27 @@ internal static class ParseHelpers
             return false;
         }
     }
+
+    public static bool TryParseOutputFormat(string value, string defaultValue)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            // Default to XML if no value is provided
+            return true;
+        }
+
+        bool valid = value.Trim().ToLowerInvariant() switch
+        {
+            "gitlab" => true,
+            "xml" => true,
+            _ => false
+        };
+
+        if (!valid)
+        {
+            WriteLine($"Unknown output format '{value}'.", Verbosity.Quiet);
+        }
+
+        return valid;
+    }
 }

--- a/src/CommandLine/ParseHelpers.cs
+++ b/src/CommandLine/ParseHelpers.cs
@@ -350,7 +350,7 @@ internal static class ParseHelpers
         }
     }
 
-    public static bool TryParseOutputFormat(string value, string defaultValue)
+    public static bool TryParseOutputFormat(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
         {

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -338,6 +338,9 @@ internal static class Program
         if (!TryParsePaths(options.Paths, out ImmutableArray<PathInfo> paths))
             return ExitCodes.Error;
 
+        if (!options.TryParseOutputFormat("xml"))
+            return ExitCodes.Error;
+
         var command = new AnalyzeCommand(options, severityLevel, projectFilter, CreateFileSystemFilter(options));
 
         CommandStatus status = await command.ExecuteAsync(paths, options.MSBuildPath, options.Properties);

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -338,7 +338,7 @@ internal static class Program
         if (!TryParsePaths(options.Paths, out ImmutableArray<PathInfo> paths))
             return ExitCodes.Error;
 
-        if (!options.TryParseOutputFormat("xml"))
+        if (!options.ValidateOutputFormat())
             return ExitCodes.Error;
 
         var command = new AnalyzeCommand(options, severityLevel, projectFilter, CreateFileSystemFilter(options));


### PR DESCRIPTION
Fixes #1631

Add support for GitLab output format in AnalyzeCommand

This commit adds support for the GitLab output format in the `AnalyzeCommand` class. Now, when the `OutputFormat` option is set to "gitlab", the analysis results will be serialized in the GitLab JSON format using the `DiagnosticGitLabJsonSerializer` class, instead of the default XML format. This enables users to generate diagnostic reports compatible with GitLab's security scanning features.