### PR TITLE
New Fix Bracket Formatting Of List Analyzer and Fix Provider

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,10 @@ indent_style = space
 [*.{cs,csx}]
 indent_size = 4
 
-[Analyzers.xml]
+[*.xml]
 indent_size = 2
+
+[Analyzers.xml]
 trim_trailing_whitespace = false
 
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,10 @@ indent_style = space
 [*.{cs,csx}]
 indent_size = 4
 
+[Analyzers.xml]
+indent_size = 2
+trim_trailing_whitespace = false
+
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options
 
 # New-line options

--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,7 @@ publish/
 *.[Pp]ublish.xml
 *.azurePubxml
 
-# TODO: Un-comment the next line if you do not want to checkin 
+# TODO: Un-comment the next line if you do not want to checkin
 # your web deploy settings because they may include unencrypted
 # passwords
 #*.pubxml
@@ -245,3 +245,6 @@ ModelManifest.xml
 .fake/
 
 .DS_Store
+
+# JetBrains Rider setting files
+.idea/

--- a/src/Analyzers.xml
+++ b/src/Analyzers.xml
@@ -7820,6 +7820,42 @@ string s = """
     </Samples>
   </Analyzer>
   <Analyzer>
+    <Id>RCS1269</Id>
+    <Identifier>FixBracketFormattingOfList</Identifier>
+    <Title>Fix bracket formatting of a list</Title>
+    <MessageFormat>Fix bracket formatting of {0}</MessageFormat>
+    <DefaultSeverity>Info</DefaultSeverity>
+    <IsEnabledByDefault>false</IsEnabledByDefault>
+    <Summary>
+      This analyzer:
+        * adds new line after an opening bracket of method definition or call
+        * adds new line before a closing bracket of method definition or call
+        * aligns the closing bracket with the block containing its opening bracket
+      The analyzer works only for multi-line declarations.
+    </Summary>
+    <Samples>
+      <Sample>
+        <Before><![CDATA[void M(object x,
+        object y)
+{
+}]]></Before>
+        <After><![CDATA[void M(
+    object x,
+    object y
+)
+{
+}]]></After>
+      </Sample>
+      <Sample>
+        <Before><![CDATA[Method(xParameter,
+    yParameter);]]></Before>
+        <After><![CDATA[Method(xParameter,
+            yParameter
+        );]]></After>
+      </Sample>
+    </Samples>
+  </Analyzer>
+  <Analyzer>
     <Id>RCS9001</Id>
     <Identifier>UsePatternMatching</Identifier>
     <Title>Use pattern matching</Title>

--- a/src/Analyzers.xml
+++ b/src/Analyzers.xml
@@ -7826,6 +7826,9 @@ string s = """
     <MessageFormat>Fix bracket formatting of {0}</MessageFormat>
     <DefaultSeverity>Info</DefaultSeverity>
     <IsEnabledByDefault>false</IsEnabledByDefault>
+    <ConfigOptions>
+      <Option Key="target_braces_style" />
+    </ConfigOptions>
     <Summary>
       This analyzer:
         * adds new line after an opening bracket of method definition or call

--- a/src/Analyzers.xml
+++ b/src/Analyzers.xml
@@ -7831,8 +7831,8 @@ string s = """
     </ConfigOptions>
     <Summary>
       This analyzer:
-        * adds new line after an opening bracket of method definition or call
-        * adds new line before a closing bracket of method definition or call
+        * adds new line after an opening bracket of argument/parameter lists and similar lists
+        * adds new line before a closing bracket of argument/parameter lists and similar lists
         * aligns the closing bracket with the block containing its opening bracket
       The analyzer works only for multi-line declarations.
     </Summary>
@@ -7852,9 +7852,10 @@ string s = """
       <Sample>
         <Before><![CDATA[Method(xParameter,
     yParameter);]]></Before>
-        <After><![CDATA[Method(xParameter,
-            yParameter
-        );]]></After>
+        <After><![CDATA[Method(
+    xParameter,
+    yParameter
+);]]></After>
       </Sample>
     </Samples>
   </Analyzer>

--- a/src/Common/CSharp/CodeStyle/TargetBracesStyle.cs
+++ b/src/Common/CSharp/CodeStyle/TargetBracesStyle.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Roslynator.CSharp.CodeStyle;
 
+[Flags]
 public enum TargetBracesStyle
 {
     None,
     Opening,
     Closing,
-    Both
+    Both = Opening | Closing,
 }

--- a/src/Common/CSharp/CodeStyle/TargetBracesStyle.cs
+++ b/src/Common/CSharp/CodeStyle/TargetBracesStyle.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Roslynator.CSharp.CodeStyle;
+
+public enum TargetBracesStyle
+{
+    None,
+    Opening,
+    Closing,
+    Both
+}

--- a/src/Common/CSharp/Extensions/CodeStyleExtensions.cs
+++ b/src/Common/CSharp/Extensions/CodeStyleExtensions.cs
@@ -656,10 +656,11 @@ internal static class CodeStyleExtensions
         return context.GetConfigOptions().GetNullConditionalOperatorNewLinePosition(defaultValue);
     }
 
-    public static TargetBracesStyle GetTargetBracesStyle(this SyntaxNodeAnalysisContext context)
-    {
-        AnalyzerConfigOptions configOptions = context.GetConfigOptions();
+    public static TargetBracesStyle GetTargetBracesStyle(this SyntaxNodeAnalysisContext context) =>
+        context.GetConfigOptions().GetTargetBracesStyle();
 
+    public static TargetBracesStyle GetTargetBracesStyle(this AnalyzerConfigOptions configOptions)
+    {
         if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.TargetBracesStyle, out string rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.TargetBracesStyle_Both, StringComparison.OrdinalIgnoreCase))

--- a/src/Common/CSharp/Extensions/CodeStyleExtensions.cs
+++ b/src/Common/CSharp/Extensions/CodeStyleExtensions.cs
@@ -656,6 +656,29 @@ internal static class CodeStyleExtensions
         return context.GetConfigOptions().GetNullConditionalOperatorNewLinePosition(defaultValue);
     }
 
+    public static TargetBracesStyle GetTargetBracesStyle(this SyntaxNodeAnalysisContext context)
+    {
+        AnalyzerConfigOptions configOptions = context.GetConfigOptions();
+
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.TargetBracesStyle, out string rawValue))
+        {
+            if (string.Equals(rawValue, ConfigOptionValues.TargetBracesStyle_Both, StringComparison.OrdinalIgnoreCase))
+            {
+                return TargetBracesStyle.Both;
+            }
+            else if (string.Equals(rawValue, ConfigOptionValues.TargetBracesStyle_Closing, StringComparison.OrdinalIgnoreCase))
+            {
+                return TargetBracesStyle.Closing;
+            }
+            else if (string.Equals(rawValue, ConfigOptionValues.TargetBracesStyle_Opening, StringComparison.OrdinalIgnoreCase))
+            {
+                return TargetBracesStyle.Opening;
+            }
+        }
+
+        return TargetBracesStyle.None;
+    }
+
     private static bool TryGetNewLinePosition(
         AnalyzerConfigOptions configOptions,
         ConfigOptionDescriptor option,

--- a/src/Common/CSharp/SyntaxTriviaAnalysis.cs
+++ b/src/Common/CSharp/SyntaxTriviaAnalysis.cs
@@ -118,8 +118,18 @@ internal static class SyntaxTriviaAnalysis
             return CSharpFactory.EmptyWhitespace();
 
         TextSpan span = nodeOrToken.Span;
+        FileLinePositionSpan linePositionSpan = tree.GetLineSpan(span, cancellationToken);
 
-        int lineStartIndex = span.Start - tree.GetLineSpan(span, cancellationToken).StartLinePosition.Character;
+        SourceText sourceText = tree.GetText(cancellationToken);
+        int lineStartPosition = sourceText.Lines.GetPosition(new LinePosition(linePositionSpan.StartLinePosition.Line, 0));
+
+        // Span starts at the beginning of the line = no indentation
+        if (span.Start == lineStartPosition)
+        {
+            return CSharpFactory.EmptyWhitespace();
+        }
+
+        int lineStartIndex = span.Start - linePositionSpan.StartLinePosition.Character;
 
         SyntaxTriviaList leading = nodeOrToken.GetLeadingTrivia();
 
@@ -205,6 +215,7 @@ internal static class SyntaxTriviaAnalysis
                 || node is AccessorDeclarationSyntax;
         }
     }
+
 
     public static string GetIncreasedIndentation(SyntaxNode node, AnalyzerConfigOptions configOptions, CancellationToken cancellationToken = default)
     {

--- a/src/Common/ConfigOptionKeys.Generated.cs
+++ b/src/Common/ConfigOptionKeys.Generated.cs
@@ -37,6 +37,7 @@ namespace Roslynator
         public const string PrefixFieldIdentifierWithUnderscore               = "roslynator_prefix_field_identifier_with_underscore";
         public const string SuppressUnityScriptMethods                        = "roslynator_suppress_unity_script_methods";
         public const string TabLength                                         = "roslynator_tab_length";
+        public const string TargetBracesStyle                                 = "roslynator_target_braces_style";
         public const string TrailingCommaStyle                                = "roslynator_trailing_comma_style";
         public const string UnityCodeAnalysisEnabled                          = "roslynator_unity_code_analysis.enabled";
         public const string UseAnonymousFunctionOrMethodGroup                 = "roslynator_use_anonymous_function_or_method_group";

--- a/src/Common/ConfigOptionValues.Generated.cs
+++ b/src/Common/ConfigOptionValues.Generated.cs
@@ -52,6 +52,10 @@ namespace Roslynator
         public const string ObjectCreationTypeStyle_Explicit                                            = "explicit";
         public const string ObjectCreationTypeStyle_Implicit                                            = "implicit";
         public const string ObjectCreationTypeStyle_ImplicitWhenTypeIsObvious                           = "implicit_when_type_is_obvious";
+        public const string TargetBracesStyle_None                                                      = "none";
+        public const string TargetBracesStyle_Opening                                                   = "opening";
+        public const string TargetBracesStyle_Closing                                                   = "closing";
+        public const string TargetBracesStyle_Both                                                      = "both";
         public const string TrailingCommaStyle_Include                                                  = "include";
         public const string TrailingCommaStyle_Omit                                                     = "omit";
         public const string TrailingCommaStyle_OmitWhenSingleLine                                       = "omit_when_single_line";

--- a/src/Common/ConfigOptions.Generated.cs
+++ b/src/Common/ConfigOptions.Generated.cs
@@ -196,6 +196,12 @@ namespace Roslynator
             defaultValuePlaceholder: "<NUM>", 
             description:             "A number of spaces that are equivalent to a tab character");
 
+        public static readonly ConfigOptionDescriptor TargetBracesStyle = new(
+            key:                     ConfigOptionKeys.TargetBracesStyle, 
+            defaultValue:            "none", 
+            defaultValuePlaceholder: "both|closing|none|opening", 
+            description:             "Define which braces should be used as a target of the code fix");
+
         public static readonly ConfigOptionDescriptor TrailingCommaStyle = new(
             key:                     ConfigOptionKeys.TrailingCommaStyle, 
             defaultValue:            null, 

--- a/src/Common/DiagnosticIdentifiers.Generated.cs
+++ b/src/Common/DiagnosticIdentifiers.Generated.cs
@@ -280,5 +280,6 @@ namespace Roslynator
         public const string UseRawStringLiteral = "RCS1266";
         public const string UseStringInterpolationInsteadOfStringConcat = "RCS1267";
         public const string SimplifyNumericComparison = "RCS1268";
+        public const string FixBracketFormattingOfList = "RCS1269";
     }
 }

--- a/src/Common/DiagnosticRules.Generated.cs
+++ b/src/Common/DiagnosticRules.Generated.cs
@@ -3323,5 +3323,17 @@ namespace Roslynator
             helpLinkUri:        DiagnosticIdentifiers.SimplifyNumericComparison, 
             customTags:         []);
 
+        /// <summary>RCS1269</summary>
+        public static readonly DiagnosticDescriptor FixBracketFormattingOfList = DiagnosticDescriptorFactory.Create(
+            id:                 DiagnosticIdentifiers.FixBracketFormattingOfList, 
+            title:              "Fix bracket formatting of a list", 
+            messageFormat:      "Fix bracket formatting of {0}", 
+            category:           DiagnosticCategories.Roslynator, 
+            defaultSeverity:    DiagnosticSeverity.Info, 
+            isEnabledByDefault: false, 
+            description:        null, 
+            helpLinkUri:        DiagnosticIdentifiers.FixBracketFormattingOfList, 
+            customTags:         []);
+
     }
 }

--- a/src/ConfigOptions.xml
+++ b/src/ConfigOptions.xml
@@ -237,6 +237,15 @@
       <Value>when_type_is_obvious</Value>
     </Values>
   </Option>
+  <Option Id="TargetBracesStyle">
+    <Description>Define which braces should be used as a target of the code fix</Description>
+    <Values>
+      <Value IsDefault="true">none</Value>
+      <Value>opening</Value>
+      <Value>closing</Value>
+      <Value>both</Value>
+    </Values>
+  </Option>
   <!--
   <Option Id="">
     <Key></Key>

--- a/src/Formatting.Analyzers.CodeFixes/CSharp/FixBracketFormattingOfListCodeFixProvider.cs
+++ b/src/Formatting.Analyzers.CodeFixes/CSharp/FixBracketFormattingOfListCodeFixProvider.cs
@@ -199,8 +199,8 @@ public sealed class FixBracketFormattingOfListCodeFixProvider : BaseCodeFixProvi
             {
                 SyntaxToken nextToken = openNodeOrToken.GetNextToken();
 
-                int bracketLine = openNodeOrToken.GetSpanStartLine();
-                int nextTokenLine = nextToken.GetSpanStartLine();
+                int bracketLine = openNodeOrToken.GetSpanStartLine(cancellationToken);
+                int nextTokenLine = nextToken.GetSpanStartLine(cancellationToken);
 
                 if (bracketLine == nextTokenLine)
                 {
@@ -219,12 +219,12 @@ public sealed class FixBracketFormattingOfListCodeFixProvider : BaseCodeFixProvi
             {
                 SyntaxToken previousToken = closeNodeOrToken.GetPreviousToken();
 
-                int bracketLine = closeNodeOrToken.GetSpanStartLine();
-                int previousTokenLine = previousToken.GetSpanEndLine();
+                int bracketLine = closeNodeOrToken.GetSpanStartLine(cancellationToken);
+                int previousTokenLine = previousToken.GetSpanEndLine(cancellationToken);
 
                 if (bracketLine == previousTokenLine)
                 {
-                    string indentation = SyntaxTriviaAnalysis.DetermineIndentation(listNode, cancellationToken).ToString();
+                    string indentation = SyntaxTriviaAnalysis.DetermineIndentation(listNode, searchInAccessors: false, cancellationToken).ToString();
 
                     textChanges.Add(
                         new TextChange(
@@ -235,8 +235,8 @@ public sealed class FixBracketFormattingOfListCodeFixProvider : BaseCodeFixProvi
                 }
                 else
                 {
-                    SyntaxTrivia listNodeIndent = SyntaxTriviaAnalysis.DetermineIndentation(listNode);
-                    SyntaxTrivia bracketIndent = SyntaxTriviaAnalysis.DetermineIndentation(closeNodeOrToken);
+                    SyntaxTrivia listNodeIndent = SyntaxTriviaAnalysis.DetermineIndentation(listNode, searchInAccessors: false, cancellationToken);
+                    SyntaxTrivia bracketIndent = SyntaxTriviaAnalysis.DetermineIndentation(closeNodeOrToken, searchInAccessors: false, cancellationToken);
                     if (listNodeIndent.Span.Length != bracketIndent.Span.Length)
                     {
                         TextSpan span =

--- a/src/Formatting.Analyzers.CodeFixes/CSharp/FixBracketFormattingOfListCodeFixProvider.cs
+++ b/src/Formatting.Analyzers.CodeFixes/CSharp/FixBracketFormattingOfListCodeFixProvider.cs
@@ -49,6 +49,7 @@ public sealed class FixBracketFormattingOfListCodeFixProvider : BaseCodeFixProvi
                         case SyntaxKind.TupleExpression:
                         case SyntaxKind.ArrayInitializerExpression:
                         case SyntaxKind.CollectionInitializerExpression:
+                        case SyntaxKind.CollectionExpression:
                         case SyntaxKind.ComplexElementInitializerExpression:
                         case SyntaxKind.ObjectInitializerExpression:
                             return true;
@@ -160,6 +161,14 @@ public sealed class FixBracketFormattingOfListCodeFixProvider : BaseCodeFixProvi
                         GetEquivalenceKey(diagnostic)
                     );
                 }
+                case CollectionExpressionSyntax collectionExpression:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => Fix(collectionExpression, collectionExpression.OpenBracketToken, collectionExpression.CloseBracketToken, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
                 default:
                 {
                     throw new InvalidOperationException();
@@ -211,7 +220,7 @@ public sealed class FixBracketFormattingOfListCodeFixProvider : BaseCodeFixProvi
                 SyntaxToken previousToken = closeNodeOrToken.GetPreviousToken();
 
                 int bracketLine = closeNodeOrToken.GetSpanStartLine();
-                int previousTokenLine = previousToken.GetSpanStartLine();
+                int previousTokenLine = previousToken.GetSpanEndLine();
 
                 if (bracketLine == previousTokenLine)
                 {

--- a/src/Formatting.Analyzers.CodeFixes/CSharp/FixBracketFormattingOfListCodeFixProvider.cs
+++ b/src/Formatting.Analyzers.CodeFixes/CSharp/FixBracketFormattingOfListCodeFixProvider.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Roslynator.Formatting.CodeFixes.CSharp;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FixBracketFormattingOfListCodeFixProvider))]
+[Shared]
+public sealed class FixBracketFormattingOfListCodeFixProvider : BaseCodeFixProvider
+{
+    private const string Title = "Fix formatting";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticIdentifiers.FixFormattingOfList);
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode root = await context.GetSyntaxRootAsync().ConfigureAwait(false);
+
+        if (!TryFindFirstAncestorOrSelf(
+                root,
+                context.Span,
+                out SyntaxNode node,
+                predicate: f =>
+                {
+                    switch (f.Kind())
+                    {
+                        case SyntaxKind.ParameterList:
+                        case SyntaxKind.BracketedParameterList:
+                        case SyntaxKind.TypeParameterList:
+                        case SyntaxKind.ArgumentList:
+                        case SyntaxKind.BracketedArgumentList:
+                        case SyntaxKind.AttributeArgumentList:
+                        case SyntaxKind.TypeArgumentList:
+                        case SyntaxKind.AttributeList:
+                        case SyntaxKind.BaseList:
+                        case SyntaxKind.TupleType:
+                        case SyntaxKind.TupleExpression:
+                        case SyntaxKind.ArrayInitializerExpression:
+                        case SyntaxKind.CollectionInitializerExpression:
+                        case SyntaxKind.ComplexElementInitializerExpression:
+                        case SyntaxKind.ObjectInitializerExpression:
+                            return true;
+                        default:
+                            return false;
+                    }
+                }
+            )
+        )
+        {
+            return;
+        }
+
+        Document document = context.Document;
+        Diagnostic diagnostic = context.Diagnostics[0];
+        CodeAction codeAction = CreateCodeAction();
+
+        context.RegisterCodeFix(codeAction, diagnostic);
+
+        CodeAction CreateCodeAction()
+        {
+            switch (node)
+            {
+                case ParameterListSyntax parameterList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, parameterList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case BracketedParameterListSyntax bracketedParameterList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, bracketedParameterList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case TypeParameterListSyntax typeParameterList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, typeParameterList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case ArgumentListSyntax argumentList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, argumentList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case BracketedArgumentListSyntax bracketedArgumentList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, bracketedArgumentList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case AttributeArgumentListSyntax attributeArgumentList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, attributeArgumentList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case TypeArgumentListSyntax typeArgumentList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, typeArgumentList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case AttributeListSyntax attributeList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, attributeList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case BaseListSyntax baseList:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, baseList, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case TupleTypeSyntax tupleType:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, tupleType, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case TupleExpressionSyntax tupleExpression:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, tupleExpression, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                case InitializerExpressionSyntax initializerExpression:
+                {
+                    return CodeAction.Create(
+                        Title,
+                        ct => CodeFixHelpers.FixListAsync(document, initializerExpression, ListFixMode.Fix, ct),
+                        GetEquivalenceKey(diagnostic)
+                    );
+                }
+                default:
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+        }
+    }
+}

--- a/src/Formatting.Analyzers/CSharp/FixBracketFormattingOfListAnalyzer.cs
+++ b/src/Formatting.Analyzers/CSharp/FixBracketFormattingOfListAnalyzer.cs
@@ -30,8 +30,6 @@ public sealed class FixBracketFormattingOfListAnalyzer : BaseDiagnosticAnalyzer
     {
         base.Initialize(context);
 
-        // Add if statement
-
         context.RegisterSyntaxNodeAction(f => AnalyzeParameterList(f), SyntaxKind.ParameterList);
         context.RegisterSyntaxNodeAction(f => AnalyzeBracketedParameterList(f), SyntaxKind.BracketedParameterList);
         context.RegisterSyntaxNodeAction(f => AnalyzeTypeParameterList(f), SyntaxKind.TypeParameterList);

--- a/src/Formatting.Analyzers/CSharp/FixBracketFormattingOfListAnalyzer.cs
+++ b/src/Formatting.Analyzers/CSharp/FixBracketFormattingOfListAnalyzer.cs
@@ -1,0 +1,501 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Roslynator.CSharp;
+using Roslynator.CSharp.CodeStyle;
+
+namespace Roslynator.Formatting.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class FixBracketFormattingOfListAnalyzer : BaseDiagnosticAnalyzer
+{
+    private static ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics;
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+    {
+        get
+        {
+            if (_supportedDiagnostics.IsDefault)
+                Immutable.InterlockedInitialize(ref _supportedDiagnostics, DiagnosticRules.FixBracketFormattingOfList);
+
+            return _supportedDiagnostics;
+        }
+    }
+
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(f => AnalyzeParameterList(f), SyntaxKind.ParameterList);
+        context.RegisterSyntaxNodeAction(f => AnalyzeBracketedParameterList(f), SyntaxKind.BracketedParameterList);
+        context.RegisterSyntaxNodeAction(f => AnalyzeTypeParameterList(f), SyntaxKind.TypeParameterList);
+
+        context.RegisterSyntaxNodeAction(f => AnalyzeArgumentList(f), SyntaxKind.ArgumentList);
+        context.RegisterSyntaxNodeAction(f => AnalyzeBracketedArgumentList(f), SyntaxKind.BracketedArgumentList);
+        context.RegisterSyntaxNodeAction(f => AnalyzeAttributeArgumentList(f), SyntaxKind.AttributeArgumentList);
+        context.RegisterSyntaxNodeAction(f => AnalyzeTypeArgumentList(f), SyntaxKind.TypeArgumentList);
+
+        context.RegisterSyntaxNodeAction(f => AnalyzeAttributeList(f), SyntaxKind.AttributeList);
+        context.RegisterSyntaxNodeAction(f => AnalyzeBaseList(f), SyntaxKind.BaseList);
+        context.RegisterSyntaxNodeAction(f => AnalyzeTupleType(f), SyntaxKind.TupleType);
+        context.RegisterSyntaxNodeAction(f => AnalyzeTupleExpression(f), SyntaxKind.TupleExpression);
+
+        context.RegisterSyntaxNodeAction(
+            f => AnalyzeInitializerExpression(f),
+            SyntaxKind.ArrayInitializerExpression,
+            SyntaxKind.CollectionInitializerExpression,
+            SyntaxKind.ComplexElementInitializerExpression,
+            SyntaxKind.ObjectInitializerExpression
+        );
+    }
+
+    private static void AnalyzeParameterList(SyntaxNodeAnalysisContext context)
+    {
+        var parameterList = (ParameterListSyntax)context.Node;
+
+        Analyze(context, parameterList.OpenParenToken, parameterList.Parameters);
+    }
+
+    private static void AnalyzeBracketedParameterList(SyntaxNodeAnalysisContext context)
+    {
+        var parameterList = (BracketedParameterListSyntax)context.Node;
+
+        Analyze(context, parameterList.OpenBracketToken, parameterList.Parameters);
+    }
+
+    private static void AnalyzeTypeParameterList(SyntaxNodeAnalysisContext context)
+    {
+        var parameterList = (TypeParameterListSyntax)context.Node;
+
+        Analyze(context, parameterList.LessThanToken, parameterList.Parameters);
+    }
+
+    private static void AnalyzeArgumentList(SyntaxNodeAnalysisContext context)
+    {
+        var argumentList = (ArgumentListSyntax)context.Node;
+
+        Analyze(context, argumentList.OpenParenToken, argumentList.Arguments);
+    }
+
+    private static void AnalyzeBracketedArgumentList(SyntaxNodeAnalysisContext context)
+    {
+        var argumentList = (BracketedArgumentListSyntax)context.Node;
+
+        Analyze(context, argumentList.OpenBracketToken, argumentList.Arguments);
+    }
+
+    private static void AnalyzeAttributeArgumentList(SyntaxNodeAnalysisContext context)
+    {
+        var argumentList = (AttributeArgumentListSyntax)context.Node;
+
+        Analyze(context, argumentList.OpenParenToken, argumentList.Arguments);
+    }
+
+    private static void AnalyzeTypeArgumentList(SyntaxNodeAnalysisContext context)
+    {
+        var argumentList = (TypeArgumentListSyntax)context.Node;
+
+        Analyze(context, argumentList.LessThanToken, argumentList.Arguments);
+    }
+
+    private static void AnalyzeAttributeList(SyntaxNodeAnalysisContext context)
+    {
+        var attributeList = (AttributeListSyntax)context.Node;
+
+        Analyze(context, attributeList.OpenBracketToken, attributeList.Attributes);
+    }
+
+    private static void AnalyzeBaseList(SyntaxNodeAnalysisContext context)
+    {
+        var baseList = (BaseListSyntax)context.Node;
+
+        Analyze(context, baseList.ColonToken, baseList.Types);
+    }
+
+    private static void AnalyzeTupleType(SyntaxNodeAnalysisContext context)
+    {
+        var tupleType = (TupleTypeSyntax)context.Node;
+
+        Analyze(context, tupleType.OpenParenToken, tupleType.Elements);
+    }
+
+    private static void AnalyzeTupleExpression(SyntaxNodeAnalysisContext context)
+    {
+        var tupleExpression = (TupleExpressionSyntax)context.Node;
+
+        Analyze(context, tupleExpression.OpenParenToken, tupleExpression.Arguments);
+    }
+
+    private static void AnalyzeInitializerExpression(SyntaxNodeAnalysisContext context)
+    {
+        var initializerExpression = (InitializerExpressionSyntax)context.Node;
+
+        Analyze(context, initializerExpression.OpenBraceToken, initializerExpression.Expressions);
+    }
+
+    private static void Analyze<TNode>(
+        SyntaxNodeAnalysisContext context,
+        SyntaxNodeOrToken openNodeOrToken,
+        SeparatedSyntaxList<TNode> nodes
+    )
+        where TNode : SyntaxNode
+    {
+        TargetBracesStyle style = context.GetTargetBracesStyle();
+
+        if (style == TargetBracesStyle.None)
+        {
+            return;
+        }
+
+        TNode first = nodes.FirstOrDefault();
+
+        if (first is null)
+            return;
+
+        TextSpan span = nodes.GetSpan(includeExteriorTrivia: false);
+
+        if (span.IsSingleLine(first.SyntaxTree))
+        {
+            if (!TriviaBlock.FromTrailing(openNodeOrToken).IsWrapped)
+                return;
+
+            int indentationLength = IndentationAnalysis.Create(openNodeOrToken.Parent, context.GetConfigOptions()).IncreasedIndentationLength;
+
+            if (indentationLength == 0)
+                return;
+
+            if (ShouldFixIndentation(first.GetLeadingTrivia(), indentationLength))
+                ReportDiagnostic();
+        }
+        else
+        {
+            TextLineCollection lines = null;
+            IndentationAnalysis indentationAnalysis = IndentationAnalysis.Create(openNodeOrToken.Parent, context.GetConfigOptions());
+            int indentationLength = indentationAnalysis.IncreasedIndentationLength;
+
+            if (indentationLength == 0)
+                return;
+
+            for (int i = nodes.Count - 1; i >= 0; i--)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                SyntaxNodeOrToken nodeOrToken = (i == 0)
+                    ? openNodeOrToken
+                    : nodes.GetSeparator(i - 1);
+
+                if (TriviaBlock.FromTrailing(nodeOrToken).IsWrapped)
+                {
+                    if (AnalyzeBlock(nodes, indentationAnalysis, SyntaxKind.OpenBracketToken, SyntaxKind.CloseBracketToken))
+                        return;
+
+                    if (ShouldFixIndentation(nodes[i].GetLeadingTrivia(), indentationLength))
+                    {
+                        ReportDiagnostic();
+                        return;
+                    }
+                }
+                else
+                {
+                    if (nodes.Count > 1
+                        && ShouldWrapAndIndent(context.Node, i))
+                    {
+                        ReportDiagnostic();
+                        return;
+                    }
+
+                    if (AnalyzeBlock(nodes, indentationAnalysis, SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken))
+                        return;
+
+                    lines ??= first.SyntaxTree.GetText().Lines;
+
+                    int lineIndex = lines.IndexOf(span.Start);
+                    if (lineIndex < lines.Count - 1)
+                    {
+                        int lineStartIndex = lines[lineIndex + 1].Start;
+
+                        if (first.Span.Contains(lineStartIndex))
+                        {
+                            SyntaxToken token = first.FindToken(lineStartIndex);
+
+                            if (!token.IsKind(SyntaxKind.None))
+                            {
+                                SyntaxTriviaList leading = token.LeadingTrivia;
+
+                                if (leading.Any())
+                                {
+                                    if (leading.FullSpan.Contains(lineStartIndex))
+                                    {
+                                        SyntaxTrivia trivia = leading.Last();
+
+                                        if (trivia.IsWhitespaceTrivia()
+                                            && trivia.SpanStart == lineStartIndex
+                                            && trivia.Span.Length != indentationLength)
+                                        {
+                                            ReportDiagnostic();
+                                            return;
+                                        }
+                                    }
+                                }
+                                else if (lineStartIndex == token.SpanStart)
+                                {
+                                    ReportDiagnostic();
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        void ReportDiagnostic()
+        {
+            DiagnosticHelpers.ReportDiagnostic(
+                context,
+                DiagnosticRules.FixBracketFormattingOfList,
+                Location.Create(first.SyntaxTree, nodes.Span),
+                GetTitle()
+            );
+        }
+
+        static bool ShouldFixIndentation(SyntaxTriviaList leading, int indentationLength)
+        {
+            SyntaxTriviaList.Reversed.Enumerator en = leading.Reverse().GetEnumerator();
+
+            if (!en.MoveNext())
+                return true;
+
+            switch (en.Current.Kind())
+            {
+                case SyntaxKind.WhitespaceTrivia:
+                {
+                    if (en.Current.Span.Length != indentationLength)
+                    {
+                        if (!en.MoveNext()
+                            || en.Current.IsEndOfLineTrivia())
+                        {
+                            return true;
+                        }
+                    }
+
+                    break;
+                }
+                case SyntaxKind.EndOfLineTrivia:
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        string GetTitle()
+        {
+            switch (context.Node.Kind())
+            {
+                case SyntaxKind.ParameterList:
+                case SyntaxKind.BracketedParameterList:
+                case SyntaxKind.TypeParameterList:
+                    return "parameters";
+                case SyntaxKind.ArgumentList:
+                case SyntaxKind.BracketedArgumentList:
+                case SyntaxKind.AttributeArgumentList:
+                case SyntaxKind.TypeArgumentList:
+                    return "arguments";
+                case SyntaxKind.AttributeList:
+                    return "attributes";
+                case SyntaxKind.BaseList:
+                    return "base types";
+                case SyntaxKind.TupleType:
+                case SyntaxKind.TupleExpression:
+                    return "a tuple";
+                case SyntaxKind.ArrayInitializerExpression:
+                case SyntaxKind.CollectionInitializerExpression:
+                case SyntaxKind.ComplexElementInitializerExpression:
+                case SyntaxKind.ObjectInitializerExpression:
+                    return "an initializer";
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        bool AnalyzeBlock(
+            SeparatedSyntaxList<TNode> nodes,
+            IndentationAnalysis indentationAnalysis,
+            SyntaxKind kind1,
+            SyntaxKind kind2)
+        {
+            if (nodes.Count == 1
+                && nodes[0].IsKind(SyntaxKind.Argument))
+            {
+                BracesBlock block = GetBracesBlock(nodes[0]);
+
+                if (block.Token.IsKind(kind1, kind2))
+                {
+                    SyntaxToken token = block.Token;
+                    SyntaxTriviaList leading = token.LeadingTrivia;
+
+                    if (leading.Any())
+                    {
+                        SyntaxTrivia trivia = leading.Last();
+
+                        if (trivia.IsWhitespaceTrivia()
+                            && trivia.SpanStart == block.LineStartIndex
+                            && trivia.Span.Length != indentationAnalysis.IndentationLength)
+                        {
+                            ReportDiagnostic();
+                        }
+                    }
+                    else if (block.LineStartIndex == token.SpanStart)
+                    {
+                        ReportDiagnostic();
+                    }
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    internal static BracesBlock GetBracesBlock(SyntaxNode node)
+    {
+        TextLineCollection lines = node.SyntaxTree.GetText().Lines;
+        TextLine line = lines.GetLineFromPosition(node.SpanStart);
+
+        int startIndex = line.End;
+
+        if (!node.FullSpan.Contains(startIndex))
+            return default;
+
+        SyntaxToken openToken = node.FindToken(startIndex);
+        SyntaxNode block = null;
+        var isOpenBraceAtEndOfLine = false;
+
+        if (AnalyzeToken(openToken, isOpen: true))
+        {
+            SyntaxTriviaList trailing = openToken.TrailingTrivia;
+
+            if (trailing.Any()
+                && trailing.Span.Contains(startIndex))
+            {
+                block = openToken.Parent;
+                isOpenBraceAtEndOfLine = true;
+            }
+        }
+
+        if (block is null)
+        {
+            startIndex = line.EndIncludingLineBreak;
+            openToken = node.FindToken(startIndex);
+
+            if (AnalyzeToken(openToken, isOpen: true))
+            {
+                SyntaxTriviaList leading = openToken.LeadingTrivia;
+
+                if ((leading.Any() && leading.Span.Contains(startIndex))
+                    || (!leading.Any() && openToken.SpanStart == startIndex))
+                {
+                    block = openToken.Parent;
+                }
+            }
+        }
+
+        if (block is not null)
+        {
+            int endIndex = lines.GetLineFromPosition(node.Span.End).Start;
+            SyntaxToken closeToken = node.FindToken(endIndex);
+
+            if (AnalyzeToken(closeToken, isOpen: false)
+                && object.ReferenceEquals(block, closeToken.Parent))
+            {
+                SyntaxTriviaList leading = closeToken.LeadingTrivia;
+
+                if ((leading.Any() && leading.Span.Contains(endIndex))
+                    || (!leading.Any() && closeToken.SpanStart == endIndex))
+                {
+                    return new BracesBlock(
+                        (isOpenBraceAtEndOfLine) ? closeToken : openToken,
+                        (isOpenBraceAtEndOfLine) ? endIndex : startIndex);
+                }
+            }
+        }
+
+        return default;
+
+        static bool AnalyzeToken(SyntaxToken token, bool isOpen)
+        {
+            if (token.IsKind((isOpen) ? SyntaxKind.OpenBraceToken : SyntaxKind.CloseBraceToken))
+            {
+                if (token.IsParentKind(SyntaxKind.Block)
+                    && (CSharpFacts.IsAnonymousFunctionExpression(token.Parent.Parent.Kind())))
+                {
+                    return true;
+                }
+
+                if (token.IsParentKind(SyntaxKind.SwitchExpression))
+                    return true;
+
+                if (token.IsParentKind(SyntaxKind.ObjectInitializerExpression)
+                    && token.Parent.Parent.IsKind(
+                        SyntaxKind.ObjectCreationExpression,
+                        SyntaxKind.AnonymousObjectCreationExpression,
+                        SyntaxKind.ImplicitObjectCreationExpression))
+                {
+                    return true;
+                }
+
+                if (token.IsParentKind(SyntaxKind.ArrayInitializerExpression)
+                    && token.Parent.Parent.IsKind(
+                        SyntaxKind.ArrayCreationExpression,
+                        SyntaxKind.ImplicitArrayCreationExpression))
+                {
+                    return true;
+                }
+            }
+#if ROSLYN_4_7
+            return token.IsKind((isOpen) ? SyntaxKind.OpenBracketToken : SyntaxKind.CloseBracketToken)
+                   && token.IsParentKind(SyntaxKind.CollectionExpression);
+#else
+            return false;
+#endif
+        }
+    }
+
+    internal static bool ShouldWrapAndIndent(SyntaxNode node, int index)
+    {
+        if (index == 0)
+        {
+            if (node.IsKind(SyntaxKind.AttributeList))
+            {
+                return false;
+            }
+            else if (node.IsKind(SyntaxKind.TupleExpression)
+                     && node.Parent is AssignmentExpressionSyntax assignmentExpression
+                     && object.ReferenceEquals(node, assignmentExpression.Left))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    internal readonly struct BracesBlock
+    {
+        public BracesBlock(SyntaxToken token, int lineStartIndex)
+        {
+            Token = token;
+            LineStartIndex = lineStartIndex;
+        }
+
+        public SyntaxToken Token { get; }
+
+        public int LineStartIndex { get; }
+    }
+}

--- a/src/Formatting.Analyzers/CSharp/FixBracketFormattingOfListAnalyzer.cs
+++ b/src/Formatting.Analyzers/CSharp/FixBracketFormattingOfListAnalyzer.cs
@@ -44,6 +44,7 @@ public sealed class FixBracketFormattingOfListAnalyzer : BaseDiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(f => AnalyzeAttributeList(f), SyntaxKind.AttributeList);
         context.RegisterSyntaxNodeAction(f => AnalyzeTupleType(f), SyntaxKind.TupleType);
         context.RegisterSyntaxNodeAction(f => AnalyzeTupleExpression(f), SyntaxKind.TupleExpression);
+        context.RegisterSyntaxNodeAction(f => AnalyzeCollectionExpression(f), SyntaxKind.CollectionExpression);
 
         context.RegisterSyntaxNodeAction(
             f => AnalyzeInitializerExpression(f),
@@ -131,6 +132,13 @@ public sealed class FixBracketFormattingOfListAnalyzer : BaseDiagnosticAnalyzer
         Analyze(context, initializerExpression.OpenBraceToken, initializerExpression.CloseBraceToken, initializerExpression.Expressions);
     }
 
+    private static void AnalyzeCollectionExpression(SyntaxNodeAnalysisContext context)
+    {
+        var collectionExpression = (CollectionExpressionSyntax)context.Node;
+
+        Analyze(context, collectionExpression.OpenBracketToken, collectionExpression.CloseBracketToken, collectionExpression.Elements);
+    }
+
     private static void Analyze<TNode>(
         SyntaxNodeAnalysisContext context,
         SyntaxToken openNodeOrToken,
@@ -192,6 +200,8 @@ public sealed class FixBracketFormattingOfListAnalyzer : BaseDiagnosticAnalyzer
             SyntaxKind.AttributeList => "attributes",
 
             SyntaxKind.TupleType or SyntaxKind.TupleExpression => "a tuple",
+
+            SyntaxKind.CollectionExpression => "a collection expression",
 
             SyntaxKind.ArrayInitializerExpression
             or SyntaxKind.CollectionInitializerExpression

--- a/src/Tests/Formatting.Analyzers.Tests/RCS1269FixBracketFormattingOfListTests.cs
+++ b/src/Tests/Formatting.Analyzers.Tests/RCS1269FixBracketFormattingOfListTests.cs
@@ -1,0 +1,1461 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslynator.Formatting.CodeFixes.CSharp;
+using Roslynator.Testing.CSharp;
+using Xunit;
+
+namespace Roslynator.Formatting.CSharp.Tests;
+
+public sealed class RCS1269FixBracketFormattingOfListTests :
+    AbstractCSharpDiagnosticVerifier<FixBracketFormattingOfListAnalyzer, FixBracketFormattingOfListCodeFixProvider>
+{
+    public override DiagnosticDescriptor Descriptor { get; } = DiagnosticRules.FixBracketFormattingOfList;
+
+    public override CSharpTestOptions Options =>
+        base.Options.AddConfigOption(ConfigOptionKeys.TargetBracesStyle, "both");
+
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Singleline_AlignedToParenthesis()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M(
+           object x, object y[|)|] 
+    {
+    }
+}
+", @"
+class C
+{
+    void M(
+           object x, object y
+    ) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Singleline_NoIndentation()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M[|(
+object x, object y)|] 
+    {
+    }
+}
+", @"
+class C
+{
+    void M(
+        object x, object y
+    ) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Singleline_EmptyLine()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|(
+            object x, object y) |]
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    object x, object y
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Singleline_Comment()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M[|( // x
+    object x, object y) |]
+    {
+    }
+}
+", @"
+class C
+{
+    void M( // x
+        object x, object y
+    ) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Singleline_EmptyLine_Comment()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M[|(
+// x
+object x, object y) |]
+    {
+    }
+}
+", @"
+class C
+{
+    void M(
+// x
+        object x, object y
+    ) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_AlignedToParenthesis()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M()
+    {
+    }
+
+    [Obsolete]
+    void M2(
+            [|object x,
+            object y) |]
+    {
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M()
+    {
+    }
+
+    [Obsolete]
+    void M2(
+        object x,
+        object y
+    ) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_AlignedToParenthesis_WhitespaceAfterParenthesis()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M( [|object x,
+           object y|]) 
+    {
+    }
+}
+", @"
+class C
+{
+    void M( object x,
+           object y
+    ) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_FirstParameterNotWrapped()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+namespace N
+{
+    class C
+    {
+        void M([|object x,
+            object y) |]
+        {
+        }
+    }
+}
+", @"
+namespace N
+{
+    class C
+    {
+        void M(object x,
+            object y
+        ) 
+        {
+        }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_TwoParametersOnSameLine()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M(
+        [|object x,
+        object y,object z) |]
+    {
+    }
+}
+", @"
+class C
+{
+    void M(
+        object x,
+        object y,object z
+    ) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_TwoParametersOnSameLine2()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M(
+        [|object x,
+        object y, object z,
+        object p4) |]
+    {
+    }
+}
+", @"
+class C
+{
+    void M(
+        object x,
+        object y, object z,
+        object p4
+    ) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_Comment()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M( // x
+ // x
+    [|object x, // xx
+    object y)|]
+    {
+    }
+}
+", @"
+class C
+{
+    void M( // x
+ // x
+    object x, // xx
+    object y
+    )
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_OpeMultilineLambdaParameter()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M(Func<string, string> x)
+    {
+        M([|f =>
+{
+    return null;
+});|]
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M(Func<string, string> x)
+    {
+        M(
+            f =>
+{
+    return null;
+}
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_FirstParameterIsMultilineLambda()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M(Func<string, string> x, object y)
+    {
+        M([|f =>
+{
+    return null;
+},
+y);|]
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M(Func<string, string> x, object y)
+    {
+        M(
+            f =>
+{
+    return null;
+},
+y
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_FirstParameterIsMultilineLambda2()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M(Func<string, string> x, object y)
+    {
+        M([|f =>
+            {
+                return null;
+            },
+y);|]
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M(Func<string, string> x, object y)
+    {
+        M(
+            f =>
+            {
+                return null;
+            },
+y
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SecondParameterIsMultilineLambdaWithExpressionBody()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M(object x, Func<string, string> y)
+    {
+        M([|x, f => f
+            .ToString()
+            .ToString());|]
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M(object x, Func<string, string> y)
+    {
+        M(
+            x, f => f
+            .ToString()
+            .ToString()
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SecondParameterIsMultilineLambdaWithBlockBody()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M(object x, Func<string, string> y)
+    {
+        M([|x, f =>
+        {
+            return f
+                .ToString()
+                .ToString();
+        });|]
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M(object x, Func<string, string> y)
+    {
+        M(
+            x, f =>
+        {
+            return f
+                .ToString()
+                .ToString();
+        }
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SecondParameterIsMultilineLambdaWithBlockBody2()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M(object x, Func<string, string> y)
+    {
+        M([|x, f => {
+            return f
+                .ToString()
+                .ToString();
+        });|]
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M(object x, Func<string, string> y)
+    {
+        M(
+            x, f => {
+            return f
+                .ToString()
+                .ToString();
+        }
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_MultilineLambda()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M(Func<string, string> x, string y)
+    {
+        M([|f =>
+        {
+            string s = null;
+
+            //x
+            return null;
+        }, y);|]
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M(Func<string, string> x, string y)
+    {
+        M(
+            f =>
+        {
+            string s = null;
+
+            //x
+            return null;
+        }, y
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_MultilineLambda2()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M(Func<string, string> x)
+    {
+        M([|f =>
+            {
+                return null;
+            });|]
+    }
+}
+", @"
+using System;
+
+class C
+{
+    void M(Func<string, string> x)
+    {
+        M(
+            f =>
+            {
+                return null;
+            }
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_IndentationsDiffer()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M(object x, string y)
+    {
+        M([|x, y.ToString()
+            .ToString());|]
+    }
+}
+", @"
+class C
+{
+    void M(object x, string y)
+    {
+        M(
+            x, y.ToString()
+            .ToString()
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_IndentationsDiffer_Tab()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+	void M(object x, string y)
+	{
+		M([|x, y.ToString()
+			.ToString());|]
+	}
+}
+", @"
+class C
+{
+	void M(object x, string y)
+	{
+		M(
+			x, y.ToString()
+			.ToString()
+		);
+	}
+}
+", options: Options.SetConfigOption("indent_style", "tab"));
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SecondParameterIsAlreadyIndented()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Linq;
+using System.Collections.Generic;
+
+class C
+{
+    void M(string x, IEnumerable<string> y)
+    {
+        M([|x,
+            Enumerable.Empty<string>()
+                .OrderBy(f => f)
+                .Select(f => f)|]
+        );
+    }
+}
+", @"
+using System.Linq;
+using System.Collections.Generic;
+
+class C
+{
+    void M(string x, IEnumerable<string> y)
+    {
+        M(
+            x,
+            Enumerable.Empty<string>()
+                .OrderBy(f => f)
+                .Select(f => f)
+        );
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_ConditionalExpression()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M(string x, string y)
+                {
+                    M([|x, (y != null)
+                        ? y
+                        : "");|]
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(string x, string y)
+                {
+                    M(
+                        x, (y != null)
+                        ? y
+                        : ""
+                    );
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SingleMultilineParameter_WrongIndentation()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M(string x)
+                {
+                    M([|(x != null)
+                ? x
+                : "");|]
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(string x)
+                {
+                    M(
+                        (x != null)
+                ? x
+                : ""
+                    );
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SingleMultilineParameter_WrongIndentation2()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M(string x)
+                {
+                    M([|M2(
+                            [|x,
+                            x)|]);|]
+                }
+            
+                string M2(string x, string y) => null;
+            }
+            """,
+            """
+            class C
+            {
+                void M(string x)
+                {
+                    M(
+                        M2(
+                            x,
+                            x
+                        )
+                    );
+                }
+            
+                string M2(string x, string y) => null;
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SingleMultilineParameter_NoIndentation()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M(string x)
+                {
+                    M([|(x != null)
+            ? x
+            : "");|]
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(string x)
+                {
+                    M(
+                        (x != null)
+            ? x
+            : ""
+                    );
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_BaseConstructorArguments()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C : B
+            {
+                public C(string x, string y) : base([|x, (y != null)
+                    ? y
+                    : "")|]
+                {
+                }
+            }
+
+            class B
+            {
+                public B(string x, string y)
+                {
+                }
+            }
+            """,
+            """
+            class C : B
+            {
+                public C(string x, string y) : base(
+                    x, (y != null)
+                    ? y
+                    : ""
+                )
+                {
+                }
+            }
+
+            class B
+            {
+                public B(string x, string y)
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_BaseConstructorArguments2()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C : B
+            {
+                public C(string x, string y)
+                    : base([|x, (y != null)
+                        ? y
+                        : "")|]
+                {
+                }
+            }
+
+            class B
+            {
+                public B(string x, string y)
+                {
+                }
+            }
+            """,
+            """
+            class C : B
+            {
+                public C(string x, string y)
+                    : base(
+                        x, (y != null)
+                        ? y
+                        : ""
+                    )
+                {
+                }
+            }
+
+            class B
+            {
+                public B(string x, string y)
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_StringLiteral()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M(string x, string y)
+                {
+                    M([|x, @"
+            a
+            b
+            c
+            ");|]
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(string x, string y)
+                {
+                    M(
+                        x, @"
+            a
+            b
+            c
+            "
+                    );
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_AttributeList()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            using System;
+
+            class C
+            {
+                [Flags, Obsolete(
+                    "",
+                    true)]|]
+                enum E
+                {
+                }
+            }
+            """,
+            """
+            using System;
+
+            class C
+            {
+                [Flags, Obsolete(
+                    "",
+                    true
+                )]
+                enum E
+                {
+                }
+            }
+            """);
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_AttributeList_NotIndented()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            using System;
+
+            class C
+            {
+                [[|Flags, Obsolete(
+            "",
+            true)]|]
+                enum E
+                {
+                }
+            }
+            """,
+            """
+            using System;
+
+            class C
+            {
+                [Flags, Obsolete(
+            "",
+            true
+                )]
+                enum E
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_OneOfParametersIsMultiline()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M([|string x, string y
+                    = default(string), string z = default)|]
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    string x, string y
+                    = default(string), string z = default
+                )
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_TupleType()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                private ([|string x, string y,
+                    string z|]) M()
+                {
+                    return ([|null, null,
+                        null|]);
+                }
+            }
+
+            """,
+            """
+            class C
+            {
+                private (
+                    string x, string y,
+                    string z
+                ) M()
+                {
+                    return (
+                        null, null,
+                        null
+                    );
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_TupleExpression()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M([|(string x, string y,
+                    string z) p)|]
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    (
+                        string x, string y,
+                        string z
+                    ) p
+                )
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_TupleExpression_LocalDeclaration()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    ([|string x,
+                        string y, string z)|] = default((string, string, string));
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M()
+                {
+                    (
+                        string x,
+                        string y, string z
+                    ) = default((string, string, string));
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_ArrayInitializer()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    var x = new string[] { [|"", default, new string(
+                        ' ',
+                        1) };|]
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M()
+                {
+                    var x = new string[] { 
+                        "", default, new string(
+                        ' ',
+                        1) 
+                    };
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_PreprocessorDirectives()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            #define FOO
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    var x = new List<string>([|new string[]
+                        {
+                            "",
+                            "",
+            #if FOO
+                            "",
+            #endif
+                        }|]);
+                }
+            }
+            """,
+            """
+            #define FOO
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    var x = new List<string>(
+                        new string[]
+                        {
+                            "",
+                            "",
+            #if FOO
+                            "",
+            #endif
+                        }
+                    );
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_SingleParameterIsMultilineLambdaWithExpressionBody()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            using System.Linq;
+
+            class C
+            {
+                void M()
+                {
+                    string s = string.Concat([|Enumerable.Empty<string>().Select([|f => {
+                        return f;
+                    })|]);|]
+                }
+            }
+            """,
+            """
+            using System.Linq;
+
+            class C
+            {
+                void M()
+                {
+                    string s = string.Concat(
+                        Enumerable.Empty<string>().Select(
+                            f => {
+                        return f;
+                    }
+                        )
+                    );
+                }
+            }
+
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task TestNoDiagnostic_Singleline()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    void M(object x, object y, object z) 
+    {
+    }
+
+    void M2(object x, object y, object z) 
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task TestNoDiagnostic_ArrayInitializerWithMultilineComment()
+    {
+        await VerifyNoDiagnosticAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    var x = new string[]
+                    {
+                        /* x */ ""
+                    };
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_LambdaBlockBodyInGlobalStatement()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            using System.Linq;
+
+            foreach (var item in Enumerable.Range(0, 10))
+            {
+                var s = "";
+            }
+
+            var items = Enumerable.Range(0, 10)
+                .Select([|f =>
+                {
+                    return f;
+                }|])
+                .Select(f => f);
+            """,
+            """
+            using System.Linq;
+
+            foreach (var item in Enumerable.Range(0, 10))
+            {
+                var s = "";
+            }
+
+            var items = Enumerable.Range(0, 10)
+                .Select(
+                    f =>
+                {
+                    return f;
+                }
+                )
+                .Select(f => f);
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_ArrayInitializerInGlobalStatement()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            Foo.Method(
+                [|foo: new Foo[]
+                {
+                    new Foo(
+                        [|"")|]
+                }|]);
+            """,
+            """
+            Foo.Method(
+                foo: new Foo[]
+                {
+                    new Foo(
+                        ""
+                    )
+                }
+            );
+            """,
+            options: Options.WithCompilationOptions(Options.CompilationOptions.WithOutputKind(OutputKind.ConsoleApplication))
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task TestNoDiagnostic_Multiline_ObjectInitializer()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                public C() { }
+
+                public C(C value) { }
+            
+                public string P { get; set; }
+
+                C M()
+                {
+                    return new C([|new C
+                    {
+                        P = ""
+                    });|]
+                }
+            }
+            """,
+            """
+            class C
+            {
+                public C() { }
+
+                public C(C value) { }
+            
+                public string P { get; set; }
+
+                C M()
+                {
+                    return new C(
+                        new C
+                    {
+                        P = ""
+                    }
+                    );
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task TestNoDiagnostic_Multiline_CollectionExpression()
+    {
+        await VerifyNoDiagnosticAsync(
+            """
+            class C
+            {
+                public C P { get; set; }
+
+                public string M1(string[] values)
+                {
+                    string x =
+                        P
+                            .M1(
+                            [
+                                // x
+                                null,
+                            ])
+                            .ToString();
+
+                    return x;
+                }
+
+                public string M2(string value, string[] values)
+                {
+                    string x =
+                        P
+                            .M2(
+                                "",
+                                [
+                                    // x
+                                    null,
+                                ])
+                                .ToString();
+
+                    return x;
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SwitchExpression()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            using System;
+
+            class C
+            {
+                string M(string value) =>
+                    M([|value switch
+                    {
+                        "a" => "a",
+                        "b" => "b",
+                        _ => throw new Exception()
+                    });|]
+            }
+            """,
+            """
+            using System;
+
+            class C
+            {
+                string M(string value) =>
+                    M(
+                        value switch
+                    {
+                        "a" => "a",
+                        "b" => "b",
+                        _ => throw new Exception()
+                    }
+                    );
+            }
+            """
+        );
+    }
+}

--- a/src/Tests/Formatting.Analyzers.Tests/RCS1269FixBracketFormattingOfListTests.cs
+++ b/src/Tests/Formatting.Analyzers.Tests/RCS1269FixBracketFormattingOfListTests.cs
@@ -1324,9 +1324,3 @@ public sealed class RCS1269FixBracketFormattingOfListTests :
         );
     }
 }
-
-// Wrapped parentness in method or tuple definition
-// (int a,
-//     int b) Method
-//     (int a,
-//         int b)

--- a/src/Tests/Formatting.Analyzers.Tests/RCS1269FixBracketFormattingOfListTests.cs
+++ b/src/Tests/Formatting.Analyzers.Tests/RCS1269FixBracketFormattingOfListTests.cs
@@ -18,58 +18,12 @@ public sealed class RCS1269FixBracketFormattingOfListTests :
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
     public async Task Test_Singleline_AlignedToParenthesis()
     {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M(
-           object x, object y[|)|] 
-    {
-    }
-}
-", @"
-class C
-{
-    void M(
-           object x, object y
-    ) 
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Singleline_NoIndentation()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M[|(
-object x, object y)|] 
-    {
-    }
-}
-", @"
-class C
-{
-    void M(
-        object x, object y
-    ) 
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Singleline_EmptyLine()
-    {
         await VerifyDiagnosticAndFixAsync(
             """
             class C
             {
                 void M[|(
-            object x, object y) |]
+                       object x, object y)|] 
                 {
                 }
             }
@@ -78,7 +32,33 @@ class C
             class C
             {
                 void M(
-                    object x, object y
+                       object x, object y
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Singleline_Unindentated()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|(
+            object x, object y)|] 
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+            object x, object y
                 ) 
                 {
                 }
@@ -90,624 +70,443 @@ class C
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
     public async Task Test_Singleline_Comment()
     {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M[|( // x
-    object x, object y) |]
-    {
-    }
-}
-", @"
-class C
-{
-    void M( // x
-        object x, object y
-    ) 
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Singleline_EmptyLine_Comment()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M[|(
-// x
-object x, object y) |]
-    {
-    }
-}
-", @"
-class C
-{
-    void M(
-// x
-        object x, object y
-    ) 
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_AlignedToParenthesis()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M()
-    {
-    }
-
-    [Obsolete]
-    void M2(
-            [|object x,
-            object y) |]
-    {
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M()
-    {
-    }
-
-    [Obsolete]
-    void M2(
-        object x,
-        object y
-    ) 
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_AlignedToParenthesis_WhitespaceAfterParenthesis()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M( [|object x,
-           object y|]) 
-    {
-    }
-}
-", @"
-class C
-{
-    void M( object x,
-           object y
-    ) 
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_FirstParameterNotWrapped()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-namespace N
-{
-    class C
-    {
-        void M([|object x,
-            object y) |]
-        {
-        }
-    }
-}
-", @"
-namespace N
-{
-    class C
-    {
-        void M(object x,
-            object y
-        ) 
-        {
-        }
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_TwoParametersOnSameLine()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M(
-        [|object x,
-        object y,object z) |]
-    {
-    }
-}
-", @"
-class C
-{
-    void M(
-        object x,
-        object y,object z
-    ) 
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_TwoParametersOnSameLine2()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M(
-        [|object x,
-        object y, object z,
-        object p4) |]
-    {
-    }
-}
-", @"
-class C
-{
-    void M(
-        object x,
-        object y, object z,
-        object p4
-    ) 
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_Comment()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M( // x
- // x
-    [|object x, // xx
-    object y)|]
-    {
-    }
-}
-", @"
-class C
-{
-    void M( // x
- // x
-    object x, // xx
-    object y
-    )
-    {
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_OpeMultilineLambdaParameter()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M(Func<string, string> x)
-    {
-        M([|f =>
-{
-    return null;
-});|]
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M(Func<string, string> x)
-    {
-        M(
-            f =>
-{
-    return null;
-}
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_FirstParameterIsMultilineLambda()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M(Func<string, string> x, object y)
-    {
-        M([|f =>
-{
-    return null;
-},
-y);|]
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M(Func<string, string> x, object y)
-    {
-        M(
-            f =>
-{
-    return null;
-},
-y
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_FirstParameterIsMultilineLambda2()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M(Func<string, string> x, object y)
-    {
-        M([|f =>
-            {
-                return null;
-            },
-y);|]
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M(Func<string, string> x, object y)
-    {
-        M(
-            f =>
-            {
-                return null;
-            },
-y
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_SecondParameterIsMultilineLambdaWithExpressionBody()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M(object x, Func<string, string> y)
-    {
-        M([|x, f => f
-            .ToString()
-            .ToString());|]
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M(object x, Func<string, string> y)
-    {
-        M(
-            x, f => f
-            .ToString()
-            .ToString()
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_SecondParameterIsMultilineLambdaWithBlockBody()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M(object x, Func<string, string> y)
-    {
-        M([|x, f =>
-        {
-            return f
-                .ToString()
-                .ToString();
-        });|]
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M(object x, Func<string, string> y)
-    {
-        M(
-            x, f =>
-        {
-            return f
-                .ToString()
-                .ToString();
-        }
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_SecondParameterIsMultilineLambdaWithBlockBody2()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M(object x, Func<string, string> y)
-    {
-        M([|x, f => {
-            return f
-                .ToString()
-                .ToString();
-        });|]
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M(object x, Func<string, string> y)
-    {
-        M(
-            x, f => {
-            return f
-                .ToString()
-                .ToString();
-        }
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_MultilineLambda()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M(Func<string, string> x, string y)
-    {
-        M([|f =>
-        {
-            string s = null;
-
-            //x
-            return null;
-        }, y);|]
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M(Func<string, string> x, string y)
-    {
-        M(
-            f =>
-        {
-            string s = null;
-
-            //x
-            return null;
-        }, y
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_MultilineLambda2()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System;
-
-class C
-{
-    void M(Func<string, string> x)
-    {
-        M([|f =>
-            {
-                return null;
-            });|]
-    }
-}
-", @"
-using System;
-
-class C
-{
-    void M(Func<string, string> x)
-    {
-        M(
-            f =>
-            {
-                return null;
-            }
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_IndentationsDiffer()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-    void M(object x, string y)
-    {
-        M([|x, y.ToString()
-            .ToString());|]
-    }
-}
-", @"
-class C
-{
-    void M(object x, string y)
-    {
-        M(
-            x, y.ToString()
-            .ToString()
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_IndentationsDiffer_Tab()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-class C
-{
-	void M(object x, string y)
-	{
-		M([|x, y.ToString()
-			.ToString());|]
-	}
-}
-", @"
-class C
-{
-	void M(object x, string y)
-	{
-		M(
-			x, y.ToString()
-			.ToString()
-		);
-	}
-}
-", options: Options.SetConfigOption("indent_style", "tab"));
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_SecondParameterIsAlreadyIndented()
-    {
-        await VerifyDiagnosticAndFixAsync(@"
-using System.Linq;
-using System.Collections.Generic;
-
-class C
-{
-    void M(string x, IEnumerable<string> y)
-    {
-        M([|x,
-            Enumerable.Empty<string>()
-                .OrderBy(f => f)
-                .Select(f => f)|]
-        );
-    }
-}
-", @"
-using System.Linq;
-using System.Collections.Generic;
-
-class C
-{
-    void M(string x, IEnumerable<string> y)
-    {
-        M(
-            x,
-            Enumerable.Empty<string>()
-                .OrderBy(f => f)
-                .Select(f => f)
-        );
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
-    public async Task Test_Multiline_ConditionalExpression()
-    {
         await VerifyDiagnosticAndFixAsync(
             """
             class C
             {
-                void M(string x, string y)
+                void M[|( // x
+                object x, object y)|] 
                 {
-                    M([|x, (y != null)
-                        ? y
-                        : "");|]
                 }
             }
             """,
             """
             class C
             {
-                void M(string x, string y)
+                void M( // x
+                object x, object y
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Singleline_EmptyLine_Comment()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|(
+            // x
+            object x, object y)|] 
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+            // x
+            object x, object y
+                ) 
+                {
+                }
+            }
+            """);
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_AlignedToParenthesis()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                }
+            
+                [Obsolete]
+                void M2[|(
+                        object x,
+                        object y)|] 
+                {
+                }
+            }
+            """,
+            """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                }
+            
+                [Obsolete]
+                void M2(
+                        object x,
+                        object y
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_AlignedToParenthesis_WhitespaceAfterParenthesis()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|( object x,
+                       object y)|] 
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    object x,
+                       object y
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_FirstParameterNotWrapped()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            namespace N
+            {
+                class C
+                {
+                    void M[|(object x,
+                        object y)|] 
+                    {
+                    }
+                }
+            }
+            """,
+            """
+            namespace N
+            {
+                class C
+                {
+                    void M(
+                        object x,
+                        object y
+                    ) 
+                    {
+                    }
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_TwoParametersOnSameLine()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|(
+                    object x,
+                    object y,object z)|] 
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    object x,
+                    object y,object z
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_ClosingBracket_Indent_Required()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|(
+                    object x,
+                    object y, object z,
+                    object p4
+                    )|] 
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    object x,
+                    object y, object z,
+                    object p4
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_ClosingBracket_Indent_Required2()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|(
+                    object x,
+                    object y, object z,
+                    object p4
+              )|] 
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    object x,
+                    object y, object z,
+                    object p4
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_ClosingBracket_Indent_Required3()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|(
+                    object x,
+                    object y, object z,
+                    object p4
+            )|] 
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    object x,
+                    object y, object z,
+                    object p4
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_ClosingBracket_Indent_Required_with_prio_comment()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|(
+                    object x,
+                    object y, object z,
+                    object p4
+                    // comment
+                    )|] 
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M(
+                    object x,
+                    object y, object z,
+                    object p4
+                    // comment
+                ) 
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_Comment()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+                void M[|( // x
+             // x
+                object x, // xx
+                object y)|]
+                {
+                }
+            }
+            """,
+            """
+            class C
+            {
+                void M( // x
+             // x
+                object x, // xx
+                object y
+                )
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_FirstParameterIsMultilineLambda()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            using System;
+
+            class C
+            {
+                void M(Func<string, string> x, object y)
+                {
+                    M[|(f =>
+            {
+                return null;
+            },
+            y)|];
+                }
+            }
+            """,
+            """
+            using System;
+
+            class C
+            {
+                void M(Func<string, string> x, object y)
                 {
                     M(
-                        x, (y != null)
-                        ? y
-                        : ""
+                        f =>
+            {
+                return null;
+            },
+            y
                     );
                 }
             }
             """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_SecondParameterIsMultilineLambdaWithExpressionBody()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            using System;
+
+            class C
+            {
+                void M(object x, Func<string, string> y)
+                {
+                    M[|(x, f => f
+                        .ToString()
+                        .ToString())|];
+                }
+            }
+            """,
+            """
+            using System;
+
+            class C
+            {
+                void M(object x, Func<string, string> y)
+                {
+                    M(
+                        x, f => f
+                        .ToString()
+                        .ToString()
+                    );
+                }
+            }
+            """
+        );
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.FixBracketFormattingOfList)]
+    public async Task Test_Multiline_IndentationsDiffer_Tab()
+    {
+        await VerifyDiagnosticAndFixAsync(
+            """
+            class C
+            {
+            	void M(object x, string y)
+            	{
+            		M[|(x, y.ToString()
+            			.ToString())|];
+            	}
+            }
+            """,
+            """
+            class C
+            {
+            	void M(object x, string y)
+            	{
+            		M(
+            			x, y.ToString()
+            			.ToString()
+            		);
+            	}
+            }
+            """,
+            options: Options.SetConfigOption("indent_style", "tab")
         );
     }
 
@@ -720,9 +519,9 @@ class C
             {
                 void M(string x)
                 {
-                    M([|(x != null)
+                    M[|((x != null)
                 ? x
-                : "");|]
+                : "")|];
                 }
             }
             """,
@@ -751,9 +550,9 @@ class C
             {
                 void M(string x)
                 {
-                    M([|M2(
-                            [|x,
-                            x)|]);|]
+                    M[|(M2[|(
+                            x,
+                            x)|])|];
                 }
             
                 string M2(string x, string y) => null;
@@ -787,9 +586,9 @@ class C
             {
                 void M(string x)
                 {
-                    M([|(x != null)
+                    M[|((x != null)
             ? x
-            : "");|]
+            : "")|];
                 }
             }
             """,
@@ -816,7 +615,7 @@ class C
             """
             class C : B
             {
-                public C(string x, string y) : base([|x, (y != null)
+                public C(string x, string y) : base[|(x, (y != null)
                     ? y
                     : "")|]
                 {
@@ -860,7 +659,7 @@ class C
             class C : B
             {
                 public C(string x, string y)
-                    : base([|x, (y != null)
+                    : base[|(x, (y != null)
                         ? y
                         : "")|]
                 {
@@ -906,11 +705,11 @@ class C
             {
                 void M(string x, string y)
                 {
-                    M([|x, @"
+                    M[|(x, @"
             a
             b
             c
-            ");|]
+            ")|];
                 }
             }
             """,
@@ -941,9 +740,9 @@ class C
 
             class C
             {
-                [Flags, Obsolete(
+                [|[Flags, Obsolete[|(
                     "",
-                    true)]|]
+                    true)|]]|]
                 enum E
                 {
                 }
@@ -954,10 +753,12 @@ class C
 
             class C
             {
-                [Flags, Obsolete(
+                [
+                    Flags, Obsolete(
                     "",
                     true
-                )]
+                    )
+                ]
                 enum E
                 {
                 }
@@ -974,9 +775,9 @@ class C
 
             class C
             {
-                [[|Flags, Obsolete(
+                [|[Flags, Obsolete(
             "",
-            true)]|]
+            true)|]]|]
                 enum E
                 {
                 }
@@ -987,10 +788,12 @@ class C
 
             class C
             {
-                [Flags, Obsolete(
+                [
+                    Flags, Obsolete(
             "",
             true
-                )]
+                    )
+                ]
                 enum E
                 {
                 }
@@ -1006,7 +809,7 @@ class C
             """
             class C
             {
-                void M([|string x, string y
+                void M[|(string x, string y
                     = default(string), string z = default)|]
                 {
                 }
@@ -1033,11 +836,11 @@ class C
             """
             class C
             {
-                private ([|string x, string y,
-                    string z|]) M()
+                private [|(string x, string y,
+                    string z)|] M()
                 {
-                    return ([|null, null,
-                        null|]);
+                    return [|(null, null,
+                        null)|];
                 }
             }
 
@@ -1067,8 +870,8 @@ class C
             """
             class C
             {
-                void M([|(string x, string y,
-                    string z) p)|]
+                void M[|([|(string x, string y,
+                    string z)|] p)|]
                 {
                 }
             }
@@ -1079,7 +882,7 @@ class C
                 void M(
                     (
                         string x, string y,
-                        string z
+                    string z
                     ) p
                 )
                 {
@@ -1098,7 +901,7 @@ class C
             {
                 void M()
                 {
-                    ([|string x,
+                    [|(string x,
                         string y, string z)|] = default((string, string, string));
                 }
             }
@@ -1127,9 +930,9 @@ class C
             {
                 void M()
                 {
-                    var x = new string[] { [|"", default, new string(
+                    var x = new string[] [|{ "", default, new string[|(
                         ' ',
-                        1) };|]
+                        1)|] }|];
                 }
             }
             """,
@@ -1141,7 +944,8 @@ class C
                     var x = new string[] { 
                         "", default, new string(
                         ' ',
-                        1) 
+                        1
+                        )
                     };
                 }
             }
@@ -1161,14 +965,14 @@ class C
             {
                 void M()
                 {
-                    var x = new List<string>([|new string[]
+                    var x = new List<string>[|(new string[]
                         {
                             "",
                             "",
             #if FOO
                             "",
             #endif
-                        }|]);
+                        })|];
                 }
             }
             """,
@@ -1207,9 +1011,9 @@ class C
             {
                 void M()
                 {
-                    string s = string.Concat([|Enumerable.Empty<string>().Select([|f => {
+                    string s = string.Concat[|(Enumerable.Empty<string>().Select[|(f => {
                         return f;
-                    })|]);|]
+                    })|])|];
                 }
             }
             """,
@@ -1229,7 +1033,6 @@ class C
                     );
                 }
             }
-
             """
         );
     }
@@ -1459,3 +1262,9 @@ class C
         );
     }
 }
+
+// Wrapped parentness in method or tuple definition
+// (int a,
+//     int b) Method
+//     (int a,
+//         int b)

--- a/src/VisualStudioCode/package/src/configurationFiles.generated.ts
+++ b/src/VisualStudioCode/package/src/configurationFiles.generated.ts
@@ -923,6 +923,9 @@ roslynator_analyzers.enabled_by_default = true|false
 # Simplify numeric comparison
 #dotnet_diagnostic.rcs1268.severity = suggestion
 
+# Fix bracket formatting of a list
+#dotnet_diagnostic.rcs1269.severity = none
+
 # Use pattern matching
 #dotnet_diagnostic.rcs9001.severity = silent
 

--- a/src/VisualStudioCode/package/src/configurationFiles.generated.ts
+++ b/src/VisualStudioCode/package/src/configurationFiles.generated.ts
@@ -124,6 +124,9 @@ roslynator_analyzers.enabled_by_default = true|false
 # Default: 4
 # Applicable to: rcs0056
 
+#roslynator_target_braces_style = both|closing|none|opening
+# Default: none
+
 #roslynator_trailing_comma_style = include|omit|omit_when_single_line
 # Applicable to: rcs1260
 

--- a/src/VisualStudioCode/package/src/configurationFiles.generated.ts
+++ b/src/VisualStudioCode/package/src/configurationFiles.generated.ts
@@ -126,6 +126,7 @@ roslynator_analyzers.enabled_by_default = true|false
 
 #roslynator_target_braces_style = both|closing|none|opening
 # Default: none
+# Applicable to: rcs1269
 
 #roslynator_trailing_comma_style = include|omit|omit_when_single_line
 # Applicable to: rcs1260
@@ -928,6 +929,7 @@ roslynator_analyzers.enabled_by_default = true|false
 
 # Fix bracket formatting of a list
 #dotnet_diagnostic.rcs1269.severity = none
+# Options: roslynator_target_braces_style
 
 # Use pattern matching
 #dotnet_diagnostic.rcs9001.severity = silent


### PR DESCRIPTION
The PR contains:
- Setting up indentation for *.xml files and disabling trimming of white spaces for Analyzers.xml. The reason is that when you do changes there IDE introduces undesirable changes in other areas basing on IDE settings as well as trims whitespaces when it is not required
- added ignoring of .idea folder as my JetBrains Rider creates it and I don't want it in the repo
- New TargetBracesStyle option for the new analyzer. 
- Added ability to skip search for indentation in parents `SyntaxTriviaAnalysis.DetermineIndentation(...)`. In my case it is not desirable. 

The PR is one of the PR I would like to raise to implement proposed in #1636 changes.

Potential next PRs are:
- Fix Bracket Formatting in ifs
- Make Structural Honest