### PR TITLE
Change Span of PutFullAccessorOnOwnLine to be correct

### DIFF
--- a/src/Formatting.Analyzers/CSharp/AccessorListAnalyzer.cs
+++ b/src/Formatting.Analyzers/CSharp/AccessorListAnalyzer.cs
@@ -59,9 +59,7 @@ public sealed class AccessorListAnalyzer : BaseDiagnosticAnalyzer
                         DiagnosticHelpers.ReportDiagnostic(
                             context,
                             DiagnosticRules.PutFullAccessorOnItsOwnLine,
-                            Location.Create(accessor.SyntaxTree, new TextSpan(accessor.SpanStart, 0)));
-
-                        break;
+                            accessor);
                     }
 
                     token = accessor.Body?.CloseBraceToken ?? accessor.SemicolonToken;


### PR DESCRIPTION
The span used to be empty causing the warning to only appear when building, and not in the IDE (at least for Rider) unless something like Error lens is active.

I changed it to match the span it expects for the code fix, and also removed the break because both accessors can be wrong, and this way it correctly marks both of them as being on the wrong line. Otherwise applying the code fix would suddenly cause a new warning for the other accessor.