### PR TITLE
Fix analyzer RCS1246 for conditional access expressions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1194](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1194) ([PR](https://github.com/dotnet/roslynator/pull/1733))
 - Fix analyzer [RCS1060](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1060) to ignore classes marked with `file` modifier ([PR](https://github.com/dotnet/roslynator/pull/1777) by @cbersch)
 - Fix analyzer [RCS1231](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1231) ([PR](https://github.com/dotnet/roslynator/pull/1774) by @cbersch)
-- Fix analyzer [RCS1246](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1246) for conditional access expressions ([PR](https://github.com/dotnet/roslynator/pull/XXXX))
+- Fix analyzer [RCS1246](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1246) for conditional access expressions ([PR](https://github.com/dotnet/roslynator/pull/1772))
 - [CLI] Fix `fix` command ignoring `--include` / `--exclude` file filter ([PR](https://github.com/dotnet/roslynator/pull/1758) by @hashiiiii)
 - [CLI] Fix loading of projects and solutions on .NET 10 SDK ([PR](https://github.com/dotnet/roslynator/pull/1783))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1194](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1194) ([PR](https://github.com/dotnet/roslynator/pull/1733))
 - Fix analyzer [RCS1060](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1060) to ignore classes marked with `file` modifier ([PR](https://github.com/dotnet/roslynator/pull/1777) by @cbersch)
 - Fix analyzer [RCS1231](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1231) ([PR](https://github.com/dotnet/roslynator/pull/1774) by @cbersch)
-- Fix analyzer [RCS1246](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1246) for conditional access expressions ([PR](https://github.com/dotnet/roslynator/pull/1772))
+- Fix analyzer [RCS1246](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1246) for conditional access expressions ([PR](https://github.com/dotnet/roslynator/pull/1772 by @krajek))
 - [CLI] Fix `fix` command ignoring `--include` / `--exclude` file filter ([PR](https://github.com/dotnet/roslynator/pull/1758) by @hashiiiii)
 - [CLI] Fix loading of projects and solutions on .NET 10 SDK ([PR](https://github.com/dotnet/roslynator/pull/1783))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix enum contained flags check for partial matches in [RCS1258](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1258) ([PR](https://github.com/dotnet/roslynator/pull/1740) by @ovska)
 - Fix analyzer [RCS1146](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1146) ([PR](https://github.com/dotnet/roslynator/pull/1747))
 - Fix analyzer [RCS1194](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1194) ([PR](https://github.com/dotnet/roslynator/pull/1733))
+- Fix analyzer [RCS1246](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1246) for conditional access expressions ([PR](https://github.com/dotnet/roslynator/pull/XXXX))
 
 ## [4.15.0] - 2025-12-14
 

--- a/src/Common/CSharp/Analysis/UseElementAccessAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseElementAccessAnalysis.cs
@@ -35,9 +35,12 @@ internal static class UseElementAccessAnalysis
         if (!HasAccessibleIndexer(typeSymbol, reducedExtensionMethodInfo.ReducedSymbolOrSymbol.ReturnType, semanticModel, invocationExpression.SpanStart))
             return false;
 
-        // Skip the speculative binding check for member binding expressions (conditional access context)
-        // because GetSpeculativeSymbolInfo cannot bind a MemberBindingExpression as a standalone expression.
-        // The infinite recursion scenario this check guards against is not applicable in conditional access.
+        // GetSpeculativeSymbolInfo cannot bind a MemberBindingExpression (conditional access,
+        // e.g. 'x?.Values.ElementAt(0)') as a standalone expression, so the speculative element
+        // access below would throw. That binding's only purpose is infinite-recursion detection,
+        // which we intentionally skip here. The recursion scenario is still technically reachable
+        // via conditional access (a member returning the enclosing indexer's type), but it's rare
+        // enough that we accept not guarding it in order to fix the crash.
         if (invocationInfo.Expression.IsKind(SyntaxKind.MemberBindingExpression))
             return true;
 

--- a/src/Common/CSharp/Analysis/UseElementAccessAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseElementAccessAnalysis.cs
@@ -35,6 +35,12 @@ internal static class UseElementAccessAnalysis
         if (!HasAccessibleIndexer(typeSymbol, reducedExtensionMethodInfo.ReducedSymbolOrSymbol.ReturnType, semanticModel, invocationExpression.SpanStart))
             return false;
 
+        // Skip the speculative binding check for member binding expressions (conditional access context)
+        // because GetSpeculativeSymbolInfo cannot bind a MemberBindingExpression as a standalone expression.
+        // The infinite recursion scenario this check guards against is not applicable in conditional access.
+        if (invocationInfo.Expression.IsKind(SyntaxKind.MemberBindingExpression))
+            return true;
+
         ElementAccessExpressionSyntax elementAccess = SyntaxFactory.ElementAccessExpression(
             invocationInfo.Expression,
             CSharpFactory.BracketedArgumentList(invocationInfo.Arguments[0]));

--- a/src/Tests/Analyzers.Tests/RCS1246UseElementAccessTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1246UseElementAccessTests.cs
@@ -336,4 +336,106 @@ class C
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseElementAccess)]
+    public async Task Test_UseElementAccessInsteadOfElementAt_ConditionalAccess()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        var x = new C();
+        var y = x?.Values.[|ElementAt(0)|];
+    }
+
+    public IReadOnlyList<int> Values => new List<int>();
+}
+", @"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        var x = new C();
+        var y = x?.Values[0];
+    }
+
+    public IReadOnlyList<int> Values => new List<int>();
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseElementAccess)]
+    public async Task Test_UseElementAccessInsteadOfFirst_ConditionalAccess()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        var x = new C();
+        var y = x?.Values.[|First()|];
+    }
+
+    public IReadOnlyList<int> Values => new List<int>();
+}
+", @"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        var x = new C();
+        var y = x?.Values[0];
+    }
+
+    public IReadOnlyList<int> Values => new List<int>();
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseElementAccess)]
+    public async Task Test_UseElementAccessInsteadOfLast_ConditionalAccess()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        var x = new C();
+        var y = x?.Values.[|Last()|];
+    }
+
+    public IReadOnlyList<int> Values => new List<int>();
+}
+", @"
+using System.Collections.Generic;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        var x = new C();
+        var y = x?.Values[^1];
+    }
+
+    public IReadOnlyList<int> Values => new List<int>();
+}
+");
+    }
 }


### PR DESCRIPTION
Smallest reproducible program I could come up with:

`new { Values = new int[0] }?.Values.ElementAt(0);`

Without the fix, the analyzer in that case throws NRE and fails the build.

