### PR TITLE
docs: mention MegaLinter in the CLI section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ dotnet tool install -g roslynator.dotnet.cli
 
 See [documentation](https://josefpihrt.github.io/docs/roslynator/cli) for further information.
 
+The CLI is also available out of the box in [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI (see its [Roslynator page](https://megalinter.io/latest/descriptors/csharp_roslynator/)).
+
 ## Testing Framework
 
 - Roslynator Testing Framework can be used for unit testing of analyzers, refactorings and code fixes.


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI, and the Roslynator CLI has been one of its embedded linters for a while now ([descriptor page](https://megalinter.io/latest/descriptors/csharp_roslynator/)).

This PR just adds a one-line mention of that in the README's Command Line Tool section, so .NET folks browsing the repo know there's a ready-made way to run Roslynator in their CI without installing anything.

Happy to reword or move it elsewhere if you prefer. Thanks for the great tool!