### PR TITLE
fix(analyzers): skip RCS1265 for catch clauses with a filter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789) by @josefpihrt)
+- Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 
 ## [4.16.0] - 2026-08-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789) by @josefpihrt)
+
 ## [4.16.0] - 2026-08-08
 
 ### Added

--- a/src/Analyzers/CSharp/Analysis/RemoveRedundantCatchBlockAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/RemoveRedundantCatchBlockAnalyzer.cs
@@ -46,6 +46,9 @@ public sealed class RemoveRedundantCatchBlockAnalyzer : BaseDiagnosticAnalyzer
         if (lastCatchClause.Declaration is not null)
             return;
 
+        if (lastCatchClause.Filter is not null)
+            return;
+
         if (lastCatchClause.Block?.Statements.Count != 1)
             return;
 

--- a/src/Tests/Analyzers.Tests/RCS1265RemoveRedundantCatchBlockTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1265RemoveRedundantCatchBlockTests.cs
@@ -176,4 +176,34 @@ class C
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveRedundantCatchBlock)]
+    public async Task Test_NoDiagnostic_CatchWhen()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    void M()
+    {
+        try
+        {
+            MethodCall();
+        }
+        catch when (Check())
+        {
+            throw;
+        }
+    }
+
+    void MethodCall()
+    {
+    }
+
+    bool Check()
+    {
+        return true;
+    }
+}
+");
+    }
 }

--- a/src/VisualStudioCode/package/CHANGELOG.md
+++ b/src/VisualStudioCode/package/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789) by @josefpihrt)
-
 ## [4.16.0] - 2026-08-08
 
 ### Added

--- a/src/VisualStudioCode/package/CHANGELOG.md
+++ b/src/VisualStudioCode/package/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789) by @josefpihrt)
+
 ## [4.16.0] - 2026-08-08
 
 ### Added


### PR DESCRIPTION
## Summary

- RCS1265 no longer reports on `catch when` clauses that only re-throw, since the filter expression still runs
- Added test covering `catch when (Check()) { throw; }`

Fixes #1754

## Test plan

- [x] `dotnet test src/Tests/Analyzers.Tests/Analyzers.Tests.csproj --filter FullyQualifiedName~RCS1265RemoveRedundantCatchBlockTests`

Made with [Cursor](https://cursor.com)