### PR TITLE
fix(analyzers): report RCS1046 for async void methods

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix
+- Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 
 ## [4.16.0] - 2026-08-08

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix
+
 ## [4.16.0] - 2026-08-08
 
 ### Added

--- a/src/Analyzers/CSharp/Analysis/NonAsynchronousMethodNameShouldNotEndWithAsyncAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/NonAsynchronousMethodNameShouldNotEndWithAsyncAnalyzer.cs
@@ -101,7 +101,8 @@ public sealed class AsyncSuffixAnalyzer : BaseDiagnosticAnalyzer
             if (methodSymbol.ImplementsInterfaceMember(allInterfaces: true))
                 return;
 
-            if (!methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, methodDeclaration.SpanStart)
+            if (!methodSymbol.IsAsync
+                && !methodSymbol.ReturnType.IsAwaitable(context.SemanticModel, methodDeclaration.SpanStart)
                 && !methodSymbol.ReturnType.OriginalDefinition.HasMetadataName(in MetadataNames.System_Collections_Generic_IAsyncEnumerable_T))
             {
                 return;

--- a/src/Tests/Analyzers.Tests/RCS1046AsynchronousMethodNameShouldEndWithAsyncTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1046AsynchronousMethodNameShouldEndWithAsyncTests.cs
@@ -137,6 +137,19 @@ struct CustomAwaiter<T> : System.Runtime.CompilerServices.INotifyCompletion
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
+    public async Task Test_AsyncVoid()
+    {
+        await VerifyDiagnosticAsync(@"
+class C
+{
+    async void [|Foo|]()
+    {
+    }
+}
+", options: Options.AddAllowedCompilerDiagnosticId("CS1998"));
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
     public async Task TestNoDiagnostic_EntryPointMethod()
     {
         await VerifyNoDiagnosticAsync(@"
@@ -150,19 +163,6 @@ class Program
     }
 }
 ");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
-    public async Task Test_AsyncVoid()
-    {
-        await VerifyDiagnosticAsync(@"
-class C
-{
-    async void [|Foo|]()
-    {
-    }
-}
-", options: Options.AddAllowedCompilerDiagnosticId("CS1998"));
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]

--- a/src/Tests/Analyzers.Tests/RCS1046AsynchronousMethodNameShouldEndWithAsyncTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1046AsynchronousMethodNameShouldEndWithAsyncTests.cs
@@ -153,6 +153,19 @@ class Program
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
+    public async Task Test_AsyncVoid()
+    {
+        await VerifyDiagnosticAsync(@"
+class C
+{
+    async void [|Foo|]()
+    {
+    }
+}
+", options: Options.AddAllowedCompilerDiagnosticId("CS1998"));
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
     public async Task TestNoDiagnostic_Interface()
     {
         await VerifyNoDiagnosticAsync(@"


### PR DESCRIPTION
## Summary

- RCS1046 now reports `async void` methods whose names do not end with `Async`
- Added test covering `async void Foo()`

Fixes #1770

## Test plan

- [x] `dotnet test src/Tests/Analyzers.Tests/Analyzers.Tests.csproj --filter FullyQualifiedName~RCS1046AsynchronousMethodNameShouldEndWithAsyncTests`

Made with [Cursor](https://cursor.com)