### PR TITLE
fix(analyzers): fix RCS0034 for primary constructor types

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses
+
 ## [4.16.0] - 2026-08-08
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses
+- Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))
 
 ## [4.16.0] - 2026-08-08
 

--- a/src/Formatting.Analyzers/CSharp/PutTypeParameterConstraintOnItsOwnLineAnalyzer.cs
+++ b/src/Formatting.Analyzers/CSharp/PutTypeParameterConstraintOnItsOwnLineAnalyzer.cs
@@ -57,7 +57,12 @@ public sealed class PutTypeParameterConstraintOnItsOwnLineAnalyzer : BaseDiagnos
         }
         else if (typeDeclaration.TypeParameterList is not null)
         {
-            Analyze(context, typeDeclaration.TypeParameterList.GreaterThanToken, constraintClauses);
+#if ROSLYN_4_7
+            SyntaxToken previous = typeDeclaration.ParameterList?.CloseParenToken ?? typeDeclaration.TypeParameterList.GreaterThanToken;
+#else
+            SyntaxToken previous = typeDeclaration.TypeParameterList.GreaterThanToken;
+#endif
+            Analyze(context, previous, constraintClauses);
         }
     }
 

--- a/src/Tests/Formatting.Analyzers.Tests/RCS0034PutTypeParameterConstraintOnItsOwnLineTests.cs
+++ b/src/Tests/Formatting.Analyzers.Tests/RCS0034PutTypeParameterConstraintOnItsOwnLineTests.cs
@@ -169,6 +169,19 @@ class C<T> where T : struct
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.PutTypeParameterConstraintOnItsOwnLine)]
+    public async Task TestNoDiagnostic_PrimaryConstructor()
+    {
+        await VerifyNoDiagnosticAsync(@"
+internal sealed class Example<TEntry, TValue>(TEntry entry)
+    where TEntry : class
+    where TValue : class
+{
+    public required TEntry Entry { get; set; } = entry;
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.PutTypeParameterConstraintOnItsOwnLine)]
     public async Task TestNoDiagnostic_BaseType()
     {
         await VerifyNoDiagnosticAsync(@"


### PR DESCRIPTION
## Summary

- RCS0034 no longer reports a false positive when a type has a primary constructor and multiple `where` clauses on separate lines
- Anchor constraint trivia on the primary constructor closing parenthesis instead of the type parameter list

Fixes #1761

## Test plan

- [x] `dotnet test src/Tests/Formatting.Analyzers.Tests/Formatting.Analyzers.Tests.csproj --filter FullyQualifiedName~RCS0034PutTypeParameterConstraintOnItsOwnLineTests`

Made with [Cursor](https://cursor.com)