### PR TITLE
fix(cli): correct GitLab output paths and line numbers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers
+
 ## [4.16.0] - 2026-08-08
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers
+- [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
 
 ## [4.16.0] - 2026-08-08
 

--- a/src/CommandLine/CommandResults/AnalyzeCommandResult.cs
+++ b/src/CommandLine/CommandResults/AnalyzeCommandResult.cs
@@ -7,11 +7,14 @@ namespace Roslynator.CommandLine;
 
 internal class AnalyzeCommandResult : CommandResult
 {
-    public AnalyzeCommandResult(CommandStatus status, ImmutableArray<ProjectAnalysisResult> analysisResults)
+    public AnalyzeCommandResult(CommandStatus status, ImmutableArray<ProjectAnalysisResult> analysisResults, string rootDirectoryPath = null)
         : base(status)
     {
         AnalysisResults = analysisResults;
+        RootDirectoryPath = rootDirectoryPath;
     }
 
     public ImmutableArray<ProjectAnalysisResult> AnalysisResults { get; }
+
+    public string RootDirectoryPath { get; }
 }

--- a/src/CommandLine/Commands/AnalyzeCommand.cs
+++ b/src/CommandLine/Commands/AnalyzeCommand.cs
@@ -81,7 +81,7 @@ internal class AnalyzeCommand : MSBuildWorkspaceCommand<AnalyzeCommandResult>
             results = await codeAnalyzer.AnalyzeSolutionAsync(solution, f => IsMatch(f), cancellationToken);
         }
 
-        return new AnalyzeCommandResult(GetCommandStatus(Options, results), results);
+        return new AnalyzeCommandResult(GetCommandStatus(Options, results), results, FileSystemFilter?.RootDirectoryPath);
     }
 
     private static CommandStatus GetCommandStatus(AnalyzeCommandLineOptions options, ImmutableArray<ProjectAnalysisResult> results)
@@ -100,7 +100,7 @@ internal class AnalyzeCommand : MSBuildWorkspaceCommand<AnalyzeCommandResult>
             CultureInfo culture = (Options.Culture is not null) ? CultureInfo.GetCultureInfo(Options.Culture) : null;
             if (!string.IsNullOrWhiteSpace(Options.OutputFormat) && Options.OutputFormat.Equals("gitlab", StringComparison.CurrentCultureIgnoreCase))
             {
-                DiagnosticGitLabJsonSerializer.Serialize(analysisResults, Options.Output, culture, FileSystemFilter.RootDirectoryPath);
+                DiagnosticGitLabJsonSerializer.Serialize(results, Options.Output, culture);
             }
             else
             {

--- a/src/CommandLine/Commands/AnalyzeCommand.cs
+++ b/src/CommandLine/Commands/AnalyzeCommand.cs
@@ -100,7 +100,7 @@ internal class AnalyzeCommand : MSBuildWorkspaceCommand<AnalyzeCommandResult>
             CultureInfo culture = (Options.Culture is not null) ? CultureInfo.GetCultureInfo(Options.Culture) : null;
             if (!string.IsNullOrWhiteSpace(Options.OutputFormat) && Options.OutputFormat.Equals("gitlab", StringComparison.CurrentCultureIgnoreCase))
             {
-                DiagnosticGitLabJsonSerializer.Serialize(analysisResults, Options.Output, culture);
+                DiagnosticGitLabJsonSerializer.Serialize(analysisResults, Options.Output, culture, FileSystemFilter.RootDirectoryPath);
             }
             else
             {

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -97,50 +96,13 @@ internal static class DiagnosticGitLabJsonSerializer
 
     private static string FormatPath(string path, string baseDirectoryPath)
     {
-        if (string.IsNullOrEmpty(path))
-            return path;
-
-        if (string.IsNullOrEmpty(baseDirectoryPath))
-            return ToForwardSlashPath(path);
-
-        string normalizedPath = NormalizePath(path);
-        string normalizedBase = NormalizePath(baseDirectoryPath);
-
-        StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-
-        if (string.Equals(normalizedPath, normalizedBase, comparison))
-            return ToForwardSlashPath(Path.GetFileName(normalizedPath));
-
-        if (normalizedPath.StartsWith(normalizedBase, comparison))
+        if (!string.IsNullOrEmpty(baseDirectoryPath)
+            && FileSystemHelpers.TryGetNormalizedFullPath(path, out string normalizedPath)
+            && FileSystemHelpers.TryGetNormalizedFullPath(baseDirectoryPath, out string normalizedBase))
         {
-            int length = normalizedBase.Length;
-
-            while (length < normalizedPath.Length && IsDirectorySeparator(normalizedPath[length]))
-                length++;
-
-            return ToForwardSlashPath(normalizedPath.Substring(length));
+            path = PathUtilities.TrimStart(normalizedPath, normalizedBase);
         }
 
-        return ToForwardSlashPath(path);
+        return path.Replace('\\', '/');
     }
-
-    private static string NormalizePath(string path)
-    {
-        try
-        {
-            return Path.GetFullPath(path);
-        }
-        catch (Exception)
-        {
-            return path;
-        }
-    }
-
-    private static bool IsDirectorySeparator(char c)
-        => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
-
-    private static string ToForwardSlashPath(string path)
-        => path.Replace('\\', '/');
 }

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -27,63 +27,73 @@ internal static class DiagnosticGitLabJsonSerializer
     public static void Serialize(
         IEnumerable<ProjectAnalysisResult> results,
         string filePath,
-        IFormatProvider formatProvider = null)
+        IFormatProvider formatProvider = null,
+        string baseDirectoryPath = null)
     {
-        IEnumerable<DiagnosticInfo> diagnostics = results.SelectMany(f => f.CompilerDiagnostics.Concat(f.Diagnostics));
-
         var reportItems = new List<GitLabIssue>();
-        foreach (DiagnosticInfo diagnostic in diagnostics)
+
+        foreach (ProjectAnalysisResult result in results)
         {
-            GitLabIssueLocation location = null;
-            if (diagnostic.LineSpan.IsValid)
+            foreach (DiagnosticInfo diagnostic in result.CompilerDiagnostics.Concat(result.Diagnostics))
             {
-                location = new GitLabIssueLocation()
+                GitLabIssueLocation location = null;
+                if (diagnostic.LineSpan.IsValid)
                 {
-                    Path = diagnostic.LineSpan.Path,
-                    Lines = new GitLabLocationLines()
+                    location = new GitLabIssueLocation()
                     {
-                        Begin = diagnostic.LineSpan.StartLinePosition.Line
-                    },
+                        Path = FormatPath(diagnostic.LineSpan.Path, baseDirectoryPath),
+                        Lines = new GitLabLocationLines()
+                        {
+                            Begin = diagnostic.LineSpan.StartLinePosition.Line + 1
+                        },
+                    };
+                }
+
+                var severity = "minor";
+                severity = diagnostic.Severity switch
+                {
+                    DiagnosticSeverity.Warning => "major",
+                    DiagnosticSeverity.Error => "critical",
+                    _ => "minor",
                 };
-            }
 
-            var severity = "minor";
-            severity = diagnostic.Severity switch
-            {
-                DiagnosticSeverity.Warning => "major",
-                DiagnosticSeverity.Error => "critical",
-                _ => "minor",
-            };
-
-            string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
-            byte[] source = Encoding.UTF8.GetBytes(issueFingerPrint);
-            byte[] hashBytes;
+                string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
+                byte[] source = Encoding.UTF8.GetBytes(issueFingerPrint);
+                byte[] hashBytes;
 #if NETFRAMEWORK
-            using (var sha256 = SHA256.Create())
-                hashBytes = sha256.ComputeHash(source);
+                using (var sha256 = SHA256.Create())
+                    hashBytes = sha256.ComputeHash(source);
 #else
-            hashBytes = SHA256.HashData(source);
+                hashBytes = SHA256.HashData(source);
 #endif
 #pragma warning disable CA1872 // Use Convert.ToHexString instead of BitConverter.ToString
-            issueFingerPrint = BitConverter.ToString(hashBytes)
-                .Replace("-", "")
-                .ToLowerInvariant();
+                issueFingerPrint = BitConverter.ToString(hashBytes)
+                    .Replace("-", "")
+                    .ToLowerInvariant();
 #pragma warning restore CA1872
 
-            reportItems.Add(new GitLabIssue()
-            {
-                Type = "issue",
-                Fingerprint = issueFingerPrint,
-                CheckName = diagnostic.Descriptor.Id,
-                Description = diagnostic.Descriptor.Title.ToString(formatProvider),
-                Severity = severity,
-                Location = location,
-                Categories = new string[] { diagnostic.Descriptor.Category },
-            });
+                reportItems.Add(new GitLabIssue()
+                {
+                    Type = "issue",
+                    Fingerprint = issueFingerPrint,
+                    CheckName = diagnostic.Descriptor.Id,
+                    Description = diagnostic.Descriptor.Title.ToString(formatProvider),
+                    Severity = severity,
+                    Location = location,
+                    Categories = new string[] { diagnostic.Descriptor.Category },
+                });
+            }
         }
 
         string report = JsonConvert.SerializeObject(reportItems, _jsonSerializerSettings);
 
         File.WriteAllText(filePath, report, Encoding.UTF8);
+    }
+
+    private static string FormatPath(string path, string baseDirectoryPath)
+    {
+        string relativePath = PathUtilities.TrimStart(path, baseDirectoryPath);
+
+        return relativePath.Replace('\\', '/');
     }
 }

--- a/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
+++ b/src/CommandLine/Json/DiagnosticGitLabJsonSerializer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -25,63 +26,67 @@ internal static class DiagnosticGitLabJsonSerializer
     };
 
     public static void Serialize(
-        IEnumerable<ProjectAnalysisResult> results,
+        IList<AnalyzeCommandResult> results,
         string filePath,
-        IFormatProvider formatProvider = null,
-        string baseDirectoryPath = null)
+        IFormatProvider formatProvider = null)
     {
         var reportItems = new List<GitLabIssue>();
 
-        foreach (ProjectAnalysisResult result in results)
+        foreach (AnalyzeCommandResult commandResult in results)
         {
-            foreach (DiagnosticInfo diagnostic in result.CompilerDiagnostics.Concat(result.Diagnostics))
+            string baseDirectoryPath = commandResult.RootDirectoryPath;
+
+            foreach (ProjectAnalysisResult result in commandResult.AnalysisResults)
             {
-                GitLabIssueLocation location = null;
-                if (diagnostic.LineSpan.IsValid)
+                foreach (DiagnosticInfo diagnostic in result.CompilerDiagnostics.Concat(result.Diagnostics))
                 {
-                    location = new GitLabIssueLocation()
+                    GitLabIssueLocation location = null;
+                    if (diagnostic.LineSpan.IsValid)
                     {
-                        Path = FormatPath(diagnostic.LineSpan.Path, baseDirectoryPath),
-                        Lines = new GitLabLocationLines()
+                        location = new GitLabIssueLocation()
                         {
-                            Begin = diagnostic.LineSpan.StartLinePosition.Line + 1
-                        },
+                            Path = FormatPath(diagnostic.LineSpan.Path, baseDirectoryPath),
+                            Lines = new GitLabLocationLines()
+                            {
+                                Begin = diagnostic.LineSpan.StartLinePosition.Line + 1
+                            },
+                        };
+                    }
+
+                    var severity = "minor";
+                    severity = diagnostic.Severity switch
+                    {
+                        DiagnosticSeverity.Warning => "major",
+                        DiagnosticSeverity.Error => "critical",
+                        _ => "minor",
                     };
-                }
 
-                var severity = "minor";
-                severity = diagnostic.Severity switch
-                {
-                    DiagnosticSeverity.Warning => "major",
-                    DiagnosticSeverity.Error => "critical",
-                    _ => "minor",
-                };
-
-                string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
-                byte[] source = Encoding.UTF8.GetBytes(issueFingerPrint);
-                byte[] hashBytes;
+                    string issueFingerPrint = $"{diagnostic.Descriptor.Id}-{diagnostic.Severity}-{location?.Path}-{location?.Lines.Begin}";
+                    byte[] source = Encoding.UTF8.GetBytes(issueFingerPrint);
+                    byte[] hashBytes;
 #if NETFRAMEWORK
-                using (var sha256 = SHA256.Create())
-                    hashBytes = sha256.ComputeHash(source);
+                    using (var sha256 = SHA256.Create())
+                        hashBytes = sha256.ComputeHash(source);
 #else
-                hashBytes = SHA256.HashData(source);
+                    hashBytes = SHA256.HashData(source);
 #endif
 #pragma warning disable CA1872 // Use Convert.ToHexString instead of BitConverter.ToString
-                issueFingerPrint = BitConverter.ToString(hashBytes)
-                    .Replace("-", "")
-                    .ToLowerInvariant();
+                    issueFingerPrint = BitConverter.ToString(hashBytes)
+                        .Replace("-", "")
+                        .ToLowerInvariant();
 #pragma warning restore CA1872
 
-                reportItems.Add(new GitLabIssue()
-                {
-                    Type = "issue",
-                    Fingerprint = issueFingerPrint,
-                    CheckName = diagnostic.Descriptor.Id,
-                    Description = diagnostic.Descriptor.Title.ToString(formatProvider),
-                    Severity = severity,
-                    Location = location,
-                    Categories = new string[] { diagnostic.Descriptor.Category },
-                });
+                    reportItems.Add(new GitLabIssue()
+                    {
+                        Type = "issue",
+                        Fingerprint = issueFingerPrint,
+                        CheckName = diagnostic.Descriptor.Id,
+                        Description = diagnostic.Descriptor.Title.ToString(formatProvider),
+                        Severity = severity,
+                        Location = location,
+                        Categories = new string[] { diagnostic.Descriptor.Category },
+                    });
+                }
             }
         }
 
@@ -92,8 +97,50 @@ internal static class DiagnosticGitLabJsonSerializer
 
     private static string FormatPath(string path, string baseDirectoryPath)
     {
-        string relativePath = PathUtilities.TrimStart(path, baseDirectoryPath);
+        if (string.IsNullOrEmpty(path))
+            return path;
 
-        return relativePath.Replace('\\', '/');
+        if (string.IsNullOrEmpty(baseDirectoryPath))
+            return ToForwardSlashPath(path);
+
+        string normalizedPath = NormalizePath(path);
+        string normalizedBase = NormalizePath(baseDirectoryPath);
+
+        StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        if (string.Equals(normalizedPath, normalizedBase, comparison))
+            return ToForwardSlashPath(Path.GetFileName(normalizedPath));
+
+        if (normalizedPath.StartsWith(normalizedBase, comparison))
+        {
+            int length = normalizedBase.Length;
+
+            while (length < normalizedPath.Length && IsDirectorySeparator(normalizedPath[length]))
+                length++;
+
+            return ToForwardSlashPath(normalizedPath.Substring(length));
+        }
+
+        return ToForwardSlashPath(path);
     }
+
+    private static string NormalizePath(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch (Exception)
+        {
+            return path;
+        }
+    }
+
+    private static bool IsDirectorySeparator(char c)
+        => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
+
+    private static string ToForwardSlashPath(string path)
+        => path.Replace('\\', '/');
 }

--- a/src/Workspaces.Core/PathUtilities.cs
+++ b/src/Workspaces.Core/PathUtilities.cs
@@ -11,17 +11,17 @@ internal static class PathUtilities
     {
         if (basePath is not null)
         {
-            if (string.Equals(path, basePath, StringComparison.Ordinal))
+            if (string.Equals(path, basePath, FileSystemHelpers.Comparison))
                 return Path.GetFileName(path);
 
-            if (path.StartsWith(basePath))
+            if (path.StartsWith(basePath, FileSystemHelpers.Comparison))
             {
                 int length = basePath.Length;
 
                 if (trimLeadingDirectorySeparator)
                 {
                     while (length < path.Length
-                        && path[length] == Path.DirectorySeparatorChar)
+                        && FileSystemHelpers.IsDirectorySeparator(path[length]))
                     {
                         length++;
                     }


### PR DESCRIPTION
## Summary

- GitLab Code Quality output now uses repository-relative paths with forward slashes
- Line numbers are 1-based to match GitLab expectations

Fixes #1744

## Test plan

- [x] `dotnet build src/CommandLine/CommandLine.csproj`

Made with [Cursor](https://cursor.com)