### PR TITLE
docs: polish hand-written documentation prose

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: JosefPihrt
+github: josefpihrt
 custom: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BX85UA346VTN6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ Guidelines for contributing to the Roslynator repo.
 
 ## Creating Issues
 
-* **DO** create a new issue rather than commenting a closed issue.
-* **DO** include analyzer/refactoring/error ID in a title (i.e. RCSxxxx, RRxxxx or CSxxxx).
+* **DO** create a new issue rather than commenting on a closed issue.
+* **DO** include the analyzer, refactoring, or error ID in the title (for example, `RCSxxxx`, `RRxxxx`, or `CSxxxx`).
 * **DO** use a descriptive title that identifies the issue or requested feature.
 * **DO** specify a detailed description of the issue or requested feature.
 * **DO** provide the following for bug reports:
@@ -25,4 +25,4 @@ Guidelines for contributing to the Roslynator repo.
 ## Coding Style
 
 * **DO** follow [.NET Runtime Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) (except using `s_` and `t_` prefix for field names).
-* **DO** install extension for VS/VS Code and follow suggestions.
+* **DO** install the Roslynator extension for Visual Studio or VS Code and follow its suggestions.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
-This project contains code from https://github.com/JosefPihrt/Orang
+This project contains code from https://github.com/josefpihrt/orang
 
 Copyright (c) Josef Pihrt. All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@
 Roslynator is a set of code analysis tools for C#, powered by [Roslyn](https://github.com/dotnet/roslyn).
 
 IMPORTANT: Analyzers will be removed from Roslynator IDE extensions in the next major release.
-It's recommended to use Roslynator NuGet packages (e.g. [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)) instead.
+Use Roslynator NuGet packages instead (for example, [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
 
 ## Tools
 
 - IDE extensions for:
   - [Visual Studio](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
   - [VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
-    - Prerequisite is to use OmniSharp. Otherwise (i.e. C# Dev Kit), use NuGet packages with analyzers, refactorings and code fixes.
+    - Requires OmniSharp. With C# Dev Kit, use NuGet packages for analyzers, refactorings, and code fixes.
   - [Open VSX](https://open-vsx.org/extension/josefpihrt-vscode/roslynator)
-- [NuGet packages](#nuget-packages) that contain collection of analyzers
+- [NuGet packages](#nuget-packages) that contain a collection of analyzers
   - [Roslynator.Analyzers](https://www.nuget.org/packages/Roslynator.Analyzers)
   - [Roslynator.CodeAnalysis.Analyzers](https://www.nuget.org/packages/Roslynator.CodeAnalysis.Analyzers)
   - [Roslynator.Formatting.Analyzers](https://www.nuget.org/packages/Roslynator.Formatting.Analyzers)
-- [Testing framework](#testing-framework) that allows unit testing of analyzers, refactoring and code fixes
-- [.NET client libraries](#client-libraries) that extend Roslyn API
+- [Testing framework](#testing-framework) that allows unit testing of analyzers, refactorings, and code fixes
+- [.NET client libraries](#client-libraries) that extend the Roslyn API
 - [Command line tool](#command-line-tool)
 
 ## Documentation
@@ -30,11 +30,9 @@ It's recommended to use Roslynator NuGet packages (e.g. [Roslynator.Analyzers](h
 
 ## Contributions
 
-Contributions are welcome! If you are interested please see:
-- documentation for [developers](https://josefpihrt.github.io/docs/roslynator/developers)
-- available [issues](https://github.com/dotnet/roslynator/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aup-for-grabs)
+Contributions are welcome! See the [developer documentation](https://josefpihrt.github.io/docs/roslynator/developers) and [open issues](https://github.com/dotnet/roslynator/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aup-for-grabs).
 
-TIP: Bugfixes or small improvements can be implemented right away. Larger task like adding new analyzer or refactoring should be discussed first.
+TIP: Bugfixes or small improvements can be implemented right away. Larger tasks, such as adding a new analyzer or refactoring, should be discussed first.
 
 ## Donations
 
@@ -54,25 +52,25 @@ For more information see the [.NET Foundation Code of Conduct](https://dotnetfou
 
 ## Command Line Tool
 
-Run following command to install Roslynator command line tool:
+To install the CLI:
 ```sh
 dotnet tool install -g roslynator.dotnet.cli
 ```
 
-See [documentation](https://josefpihrt.github.io/docs/roslynator/cli) for further information.
+See the [CLI documentation](https://josefpihrt.github.io/docs/roslynator/cli) for more information.
 
-The CLI is also available out of the box in [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI (see its [Roslynator page](https://megalinter.io/latest/descriptors/csharp_roslynator/)).
+The CLI is also integrated in [MegaLinter](https://megalinter.io/), an open-source linter aggregator for CI (see its [Roslynator page](https://megalinter.io/latest/descriptors/csharp_roslynator/)).
 
 ## Testing Framework
 
-- Roslynator Testing Framework can be used for unit testing of analyzers, refactorings and code fixes.
-- See [documentation](https://josefpihrt.github.io/docs/roslynator/testing) for further information.
+- Use the testing framework to unit-test analyzers, refactorings, and code fixes.
+- See the [testing documentation](https://josefpihrt.github.io/docs/roslynator/testing) for more information.
 
 ## Client Libraries
 
-- Roslynator client libraries are meant be used for development of your own analyzers/refactorings.
-- It does not contain any analyzers/refactorings itself.
-- See [reference](https://josefpihrt.github.io/docs/roslynator/ref).
+- The client libraries extend Roslyn and are intended for building custom analyzers and refactorings.
+- These packages do not include analyzers or refactorings.
+- See the [API reference](https://josefpihrt.github.io/docs/roslynator/ref).
 
 | Package | Version | Extends |
 | --- | --- | --- |

--- a/src/Analyzers.CodeFixes/docs/NuGetReadme.md
+++ b/src/Analyzers.CodeFixes/docs/NuGetReadme.md
@@ -6,11 +6,11 @@ A collection of 200+ [analyzers](https://josefpihrt.github.io/docs/roslynator/an
 
 * Visual Studio 2022
 * VS Code with [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension 1.21.13 or higher
-* Roslyn 3.8.0 or higher (when used directly, not as a part of IDE)
+* Roslyn 3.8.0 or higher (when used directly, not as part of an IDE)
 
 ## Usage
 
-* Add package to your project:
+* Add the package to your project:
    ```shell
    dotnet add package roslynator.analyzers
    ```

--- a/src/CSharp.Workspaces/docs/NuGetReadme.md
+++ b/src/CSharp.Workspaces/docs/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Roslynator.CSharp.Workspaces
 
-This package extends functionality of package [Microsoft.CodeAnalysis.CSharp.Workspaces](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp.Workspaces).
+This package extends the functionality of the [Microsoft.CodeAnalysis.CSharp.Workspaces](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp.Workspaces) package.
 
 ## Feedback
 

--- a/src/CSharp/docs/NuGetReadme.md
+++ b/src/CSharp/docs/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Roslynator.CSharp
 
-This package extends functionality of package [Microsoft.CodeAnalysis.CSharp](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp).
+This package extends the functionality of the [Microsoft.CodeAnalysis.CSharp](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp) package.
 
 ## Feedback
 

--- a/src/CodeAnalysis.Analyzers.CodeFixes/docs/NuGetReadme.md
+++ b/src/CodeAnalysis.Analyzers.CodeFixes/docs/NuGetReadme.md
@@ -2,17 +2,17 @@
 
 A collection of [analyzers](https://josefpihrt.github.io/docs/roslynator/analyzers) for Roslyn API, powered by [Roslyn](https://github.com/dotnet/roslyn).
 
-The package is applicable for projects that reference Roslyn packages (Microsoft.CodeAnalysis*).
+Use this package for projects that reference Roslyn (`Microsoft.CodeAnalysis*`) packages.
 
 ## Requirements
 
 * Visual Studio 2022
 * VS Code with [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension 1.21.13 or higher
-* Roslyn 3.8.0 or higher (when used directly, not as a part of IDE)
+* Roslyn 3.8.0 or higher (when used directly, not as part of an IDE)
 
 ## Usage
 
-* Add package to your project:
+* Add the package to your project:
    ```shell
    dotnet add package roslynator.codeanalysis.analyzers
    ```

--- a/src/CodeFixes/docs/NuGetReadme.md
+++ b/src/CodeFixes/docs/NuGetReadme.md
@@ -1,24 +1,24 @@
 # Roslynator.CodeFixes
 
-A collection [code fixes](https://josefpihrt.github.io/docs/roslynator/fixes) for C# compiler diagnostics, powered by [Roslyn](https://github.com/dotnet/roslyn).
+A collection of [code fixes](https://josefpihrt.github.io/docs/roslynator/fixes) for C# compiler diagnostics, powered by [Roslyn](https://github.com/dotnet/roslyn).
 
-This package is recommended to be used in an enviroment where Roslynator IDE extensions cannot be used, e.g. VS Code + C# Dev Kit.
-Otherwise, do not use this package and use IDE extension which has the same functionality.
+Use this package when Roslynator IDE extensions are unavailable, such as VS Code with C# Dev Kit.
+Otherwise, use the IDE extension instead.
 
 ## Requirements
 
 * Visual Studio 2022
 * VS Code with [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension 1.21.13 or higher
-* Roslyn 3.8.0 or higher (when used directly, not as a part of IDE)
+* Roslyn 3.8.0 or higher (when used directly, not as part of an IDE)
 
 ## Usage
 
-* Add package to your project:
+* Add the package to your project:
    ```shell
    dotnet add package roslynator.codefixes
    ```
 
-* Use EditorConfig to [configure](https://josefpihrt.github.io/docs/roslynator/configuration) analyzers.
+* Use EditorConfig to [configure](https://josefpihrt.github.io/docs/roslynator/configuration) code fixes.
 
 ## Feedback
 

--- a/src/CommandLine.DocumentationGenerator/data/analyze_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/analyze_bottom.md
@@ -1,3 +1,3 @@
 ## Redirected/Piped Input
 
-Redirected/piped input will be used as a list of project/solution paths separated with newlines.
+Redirected or piped input is treated as a list of project/solution paths, one per line.

--- a/src/CommandLine.DocumentationGenerator/data/analyze_summary.md
+++ b/src/CommandLine.DocumentationGenerator/data/analyze_summary.md
@@ -1,7 +1,7 @@
 Project or solution should be built before the command is executed.
 
 :::info
-Roslynator CLI does not contain any analyzers (such as [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)) itself.
+The CLI does not include analyzers (such as [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
 
-Analyzers are either referenced as NuGet packages or it is possible to add analyzer assemblies with parameter `--analyzer-assemblies`.
+Reference analyzers as NuGet packages, or add analyzer assemblies with `--analyzer-assemblies`.
 :::

--- a/src/CommandLine.DocumentationGenerator/data/fix_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/fix_bottom.md
@@ -1,3 +1,3 @@
 ## Redirected/Piped Input
 
-Redirected/piped input will be used as a list of project/solution paths separated with newlines.
+Redirected or piped input is treated as a list of project/solution paths, one per line.

--- a/src/CommandLine.DocumentationGenerator/data/fix_summary.md
+++ b/src/CommandLine.DocumentationGenerator/data/fix_summary.md
@@ -1,7 +1,7 @@
 Project or solution should be built before the command is executed.
 
 :::info
-Roslynator CLI does not contain any analyzers (such as [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)) itself.
+The CLI does not include analyzers (such as [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
 
-Analyzers are either referenced as NuGet packages or it is possible to add analyzer assemblies with parameter `--analyzer-assemblies`.
+Reference analyzers as NuGet packages, or add analyzer assemblies with `--analyzer-assemblies`.
 :::

--- a/src/CommandLine.DocumentationGenerator/data/format_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/format_bottom.md
@@ -1,3 +1,3 @@
 ## Redirected/Piped Input
 
-Redirected/piped input will be used as a list of project/solution paths separated with newlines.
+Redirected or piped input is treated as a list of project/solution paths, one per line.

--- a/src/CommandLine.DocumentationGenerator/data/list-symbols_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/list-symbols_bottom.md
@@ -1,3 +1,3 @@
 ## Redirected/Piped Input
 
-Redirected/piped input will be used as a list of project/solution paths separated with newlines.
+Redirected or piped input is treated as a list of project/solution paths, one per line.

--- a/src/CommandLine.DocumentationGenerator/data/lloc_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/lloc_bottom.md
@@ -1,3 +1,3 @@
 ## Redirected/Piped Input
 
-Redirected/piped input will be used as a list of project/solution paths separated with newlines.
+Redirected or piped input is treated as a list of project/solution paths, one per line.

--- a/src/CommandLine.DocumentationGenerator/data/loc_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/loc_bottom.md
@@ -1,3 +1,3 @@
 ## Redirected/Piped Input
 
-Redirected/piped input will be used as a list of project/solution paths separated with newlines.
+Redirected or piped input is treated as a list of project/solution paths, one per line.

--- a/src/CommandLine.DocumentationGenerator/data/rename-symbol_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/rename-symbol_bottom.md
@@ -1,6 +1,6 @@
 ## Redirected/Piped Input
 
-Redirected/piped input will be used as a list of project/solution paths separated with newlines.
+Redirected or piped input is treated as a list of project/solution paths, one per line.
 
 ## Examples
 
@@ -103,7 +103,7 @@ roslynator rename-symbol my.sln
 #### Notes
 
 * We assume that there are files `my.sln` and `rename-constants.cs` in the current directory.
-* If the "IsMatch" method and "GetNewName" method are defined both in the same file it is allowed to specified it only once as a value of `--match-from` option.
+* If the `IsMatch` method and `GetNewName` method are defined both in the same file it is allowed to specified it only once as a value of the `--match-from` option.
 * Because the code is marked with `auto-generated` tag we have to explicitly allow generated code with `--include-generated-code` switch.
 * The option `--scope member` is not required but it can make the process faster.
 

--- a/src/CommandLine.DocumentationGenerator/data/rename-symbol_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/rename-symbol_bottom.md
@@ -103,7 +103,7 @@ roslynator rename-symbol my.sln
 #### Notes
 
 * We assume that there are files `my.sln` and `rename-constants.cs` in the current directory.
-* If the `IsMatch` method and `GetNewName` method are defined both in the same file it is allowed to specified it only once as a value of the `--match-from` option.
+* If the `IsMatch` and `GetNewName` methods are both defined in the same file, the file can be specified just once, as the value of the `--match-from` option.
 * Because the code is marked with `auto-generated` tag we have to explicitly allow generated code with `--include-generated-code` switch.
 * The option `--scope member` is not required but it can make the process faster.
 

--- a/src/CommandLine.DocumentationGenerator/data/spellcheck_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/spellcheck_bottom.md
@@ -1,28 +1,28 @@
 ## Redirected/Piped Input
 
-Redirected/piped input will be used as a list of project/solution paths separated with newlines.
+Redirected or piped input is treated as a list of project/solution paths, one per line.
 
 ## How to Suppress Spellchecking
 
-Possible misspelling or typo is reported as a diagnostic `RCS2001`.
-Thus it is possible to suppress it as any other diagnostic. 
+Misspellings and typos are reported as diagnostic `RCS2001`.
+You can suppress it like any other diagnostic.
 
 ## List of Allowed Words
 
-* It is required to specify one or more wordlists (parameter `--words`).
-* Wordlist is defined as a text file that contains list of values separated with newlines.
-* Each value is either a valid word (for example `misspell`) or a fix in a format `<ERROR>: <FIX>` (for example `mispell: misspell`).
-* Word matching is case-insensitive by default (use option `--case-sensitive` to specify case-sensitive matching).
-* It is recommended to use [Wordb](https://github.com/JosefPihrt/Wordb/tree/main/data) wordlists that are specifically tailored to be used for spellchecking.
+* Specify one or more wordlists with the `--words` parameter.
+* A wordlist is a text file containing values separated by newlines.
+* Each value is either a valid word (for example, `misspell`) or a fix in the format `<ERROR>: <FIX>` (for example, `mispell: misspell`).
+* Word matching is case-insensitive by default (use `--case-sensitive` for case-sensitive matching).
+* [Wordb](https://github.com/josefpihrt/Wordb/tree/main/data) wordlists are tailored for spellchecking.
 
 ## Output
 
-* Command output contains up to four lists in a following order:
-  * Words containing unknown words - for example a method name that comprises multiple words where one or more of them is unknown such as `GetMaxWidht`.
-  * Unknown words - List of words that were not found in any wordlist.
-  * Auto fixes - List of automatically applied fixes.
-  * User-applied fixes - List of fixes applied by the user (when `--interactive` is set).
+* Command output contains up to four lists in the following order:
+  * Lines containing unknown words — for example, a method name made up of multiple words where one or more is unknown, such as `GetMaxWidht`.
+  * Unknown words — words not found in any wordlist.
+  * Auto fixes — automatically applied fixes.
+  * User-applied fixes — fixes applied by the user (when `--interactive` is set).
 
-These lists can be used to update wordlists so they match the code base more precisely.
+Use these lists to update wordlists so they match the codebase more closely.
 
-NOTE: The verbosity must be set to `normal` (default) or higher for the output to contain these lists.
+NOTE: Set verbosity to `normal` (default) or higher for the output to include these lists.

--- a/src/CommandLine.DocumentationGenerator/data/spellcheck_bottom.md
+++ b/src/CommandLine.DocumentationGenerator/data/spellcheck_bottom.md
@@ -18,7 +18,7 @@ You can suppress it like any other diagnostic.
 ## Output
 
 * Command output contains up to four lists in the following order:
-  * Lines containing unknown words — for example, a method name made up of multiple words where one or more is unknown, such as `GetMaxWidht`.
+  * Words containing unknown words — for example, a method name made up of multiple words where one or more is unknown, such as `GetMaxWidht`.
   * Unknown words — words not found in any wordlist.
   * Auto fixes — automatically applied fixes.
   * User-applied fixes — fixes applied by the user (when `--interactive` is set).

--- a/src/CommandLine/docs/NetCore/NuGetReadme.md
+++ b/src/CommandLine/docs/NetCore/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Roslynator Command-line Tool
 
-.NET Core global tool that allows to run [Roslyn](https://github.com/dotnet/roslyn) code analysis from command line.
+.NET global tool for running [Roslyn](https://github.com/dotnet/roslyn) code analysis from the command line.
 
 ## Requirements
 
@@ -8,27 +8,27 @@
 
 ## Installation
 
-Run following command to install Roslynator command-line tool:
+To install the CLI:
 ```shell
 dotnet tool install -g roslynator.dotnet.cli
 ```
 
 ## Usage
 
-Roslynator command-line tool does not contain any analyzers (such as [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
-Analyzers are either referenced as NuGet packages or it is possible to add analyzer assemblies with parameter `--analyzer-assemblies`.
+The CLI does not include analyzers (such as [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
+Reference analyzers as NuGet packages, or add analyzer assemblies with `--analyzer-assemblies`.
 
-Analyze project/solution:
+Analyze a project or solution:
 ```shell
 roslynator analyze
 ```
 
-Fix project/solution:
+Fix a project or solution:
 ```shell
 roslynator fix
 ```
 
-See [documentation](https://josefpihrt.github.io/docs/roslynator/cli) for a full list of commands.
+See the [CLI documentation](https://josefpihrt.github.io/docs/roslynator/cli) for the full list of commands.
 
 ## Feedback
 

--- a/src/CommandLine/docs/NetFramework/NuGetReadme.md
+++ b/src/CommandLine/docs/NetFramework/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Roslynator Command-line Tool
 
-.NET Framework stand-alone application that allows to run [Roslyn](https://github.com/dotnet/roslyn) code analysis from command line.
+.NET Framework stand-alone application for running [Roslyn](https://github.com/dotnet/roslyn) code analysis from the command line.
 
 ## Requirements
 
@@ -8,24 +8,24 @@
 
 ## Installation
 
-No installation is required. Unzip nuget package and run roslynator.exe.
+No installation is required. Unzip the NuGet package and run `roslynator.exe`.
 
 ## Usage
 
-Roslynator command-line tool does not contain any analyzers (such as [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
-Analyzers are either referenced as NuGet packages or it is possible to add analyzer assemblies with parameter `--analyzer-assemblies`.
+The CLI does not include analyzers (such as [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
+Reference analyzers as NuGet packages, or add analyzer assemblies with `--analyzer-assemblies`.
 
-Analyze project/solution:
+Analyze a project or solution:
 ```shell
 roslynator analyze
 ```
 
-Fix project/solution:
+Fix a project or solution:
 ```shell
 roslynator fix
 ```
 
-See [documentation](https://josefpihrt.github.io/docs/roslynator/cli) for a full list of commands.
+See the [CLI documentation](https://josefpihrt.github.io/docs/roslynator/cli) for the full list of commands.
 
 ## Feedback
 

--- a/src/Core/docs/NuGetReadme.md
+++ b/src/Core/docs/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Roslynator.Core
 
-This package extends functionality of package [Microsoft.CodeAnalysis.Common](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Common).
+This package extends the functionality of the [Microsoft.CodeAnalysis.Common](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Common) package.
 
 ## Feedback
 

--- a/src/Formatting.Analyzers.CodeFixes/docs/NuGetReadme.md
+++ b/src/Formatting.Analyzers.CodeFixes/docs/NuGetReadme.md
@@ -6,11 +6,11 @@ A collection of formatting [analyzers](https://josefpihrt.github.io/docs/roslyna
 
 * Visual Studio 2022
 * VS Code with [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension 1.21.13 or higher
-* Roslyn 3.8.0 or higher (when used directly, not as a part of IDE)
+* Roslyn 3.8.0 or higher (when used directly, not as part of an IDE)
 
 ## Usage
 
-* Add package to your project:
+* Add the package to your project:
    ```shell
    dotnet add package roslynator.formatting.analyzers
    ```

--- a/src/Refactorings/docs/NuGetReadme.md
+++ b/src/Refactorings/docs/NuGetReadme.md
@@ -2,23 +2,23 @@
 
 A collection of 200+ [refactorings](https://josefpihrt.github.io/docs/roslynator/refactorings) for C#, powered by [Roslyn](https://github.com/dotnet/roslyn).
 
-This package is recommended to be used in an enviroment where Roslynator IDE extensions cannot be used, e.g. VS Code + C# Dev Kit.
-Otherwise, do not use this package and use IDE extension which has the same functionality.
+Use this package when Roslynator IDE extensions are unavailable, such as VS Code with C# Dev Kit.
+Otherwise, use the IDE extension instead.
 
 ## Requirements
 
 * Visual Studio 2022
 * VS Code with [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension 1.21.13 or higher
-* Roslyn 3.8.0 or higher (when used directly, not as a part of IDE)
+* Roslyn 3.8.0 or higher (when used directly, not as part of an IDE)
 
 ## Usage
 
-* Add package to your project:
+* Add the package to your project:
    ```shell
    dotnet add package roslynator.refactorings
    ```
 
-* Use EditorConfig to [configure](https://josefpihrt.github.io/docs/roslynator/configuration) analyzers.
+* Use EditorConfig to [configure](https://josefpihrt.github.io/docs/roslynator/configuration) refactorings.
 
 ## Feedback
 

--- a/src/Tests/Testing.CSharp.MSTest/docs/NuGetReadme.md
+++ b/src/Tests/Testing.CSharp.MSTest/docs/NuGetReadme.md
@@ -1,14 +1,14 @@
 # Roslynator.Testing.CSharp.MSTest
 
-Test framework for unit testing of [Roslyn](https://github.com/dotnet/roslyn) analyzers, refactorings and code fixes.
+Testing framework for unit-testing [Roslyn](https://github.com/dotnet/roslyn) analyzers, refactorings, and code fixes.
 
 ## Usage
 
-Learn how to use the framework from actual usages in Roslynator repository:
+Examples in the Roslynator repository:
 
-* Tests of analyzers are [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/Analyzers.Tests), [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/CodeAnalysis.Analyzers.Tests) and [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/Formatting.Analyzers.Tests).
-* Tests of refactorings are [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/Refactorings.Tests).
-* Tests of fixes of compiler diagnostics are [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/CodeFixes.Tests).
+* Analyzer tests: [Analyzers.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/Analyzers.Tests), [CodeAnalysis.Analyzers.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/CodeAnalysis.Analyzers.Tests), and [Formatting.Analyzers.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/Formatting.Analyzers.Tests)
+* Refactoring tests: [Refactorings.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/Refactorings.Tests)
+* Compiler diagnostic fix tests: [CodeFixes.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/CodeFixes.Tests)
 
 ## Feedback
 

--- a/src/Tests/Testing.CSharp.Xunit/docs/NuGetReadme.md
+++ b/src/Tests/Testing.CSharp.Xunit/docs/NuGetReadme.md
@@ -1,14 +1,14 @@
 # Roslynator.Testing.CSharp.Xunit
 
-Test framework for unit testing of [Roslyn](https://github.com/dotnet/roslyn) analyzers, refactorings and code fixes.
+Testing framework for unit-testing [Roslyn](https://github.com/dotnet/roslyn) analyzers, refactorings, and code fixes.
 
 ## Usage
 
-Learn how to use the framework from actual usages in Roslynator repository:
+Examples in the Roslynator repository:
 
-* Tests of analyzers are [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/Analyzers.Tests), [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/CodeAnalysis.Analyzers.Tests) and [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/Formatting.Analyzers.Tests).
-* Tests of refactorings are [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/Refactorings.Tests).
-* Tests of fixes of compiler diagnostics are [here](https://github.com/dotnet/roslynator/tree/main/src/Tests/CodeFixes.Tests).
+* Analyzer tests: [Analyzers.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/Analyzers.Tests), [CodeAnalysis.Analyzers.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/CodeAnalysis.Analyzers.Tests), and [Formatting.Analyzers.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/Formatting.Analyzers.Tests)
+* Refactoring tests: [Refactorings.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/Refactorings.Tests)
+* Compiler diagnostic fix tests: [CodeFixes.Tests](https://github.com/dotnet/roslynator/tree/main/src/Tests/CodeFixes.Tests)
 
 ## Feedback
 

--- a/src/Tests/Testing.CSharp/docs/NuGetReadme.md
+++ b/src/Tests/Testing.CSharp/docs/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Roslynator.Testing.CSharp
 
-A shared package used by the Roslynator Testing Framework. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+A shared package used by the Roslynator Testing Framework. Do not install this package manually; it is added automatically as a dependency by packages that require it.
 
 ## Feedback
 

--- a/src/Tests/Testing.Common/docs/NuGetReadme.md
+++ b/src/Tests/Testing.Common/docs/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Roslynator.Testing.Common
 
-A shared package used by the Roslynator Testing Framework. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+A shared package used by the Roslynator Testing Framework. Do not install this package manually; it is added automatically as a dependency by packages that require it.
 
 ## Feedback
 

--- a/src/VisualStudio.Refactorings/Overview.md
+++ b/src/VisualStudio.Refactorings/Overview.md
@@ -8,12 +8,12 @@
 
 ## Donation
 
-Although Roslynator Refactorings is free of charge, any [donation](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BX85UA346VTN6) is welcome and supports further development.
+Although Roslynator Refactorings is free of charge, [donations](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BX85UA346VTN6) are welcome and support further development.
 
 ## Related Products
 
-* VS Extension [Roslynator 2019](http://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2019) contains all features - analyzers, refactorings and code fixes for CS diagnostics.
-* Package [Roslynator.Analyzers](http://www.nuget.org/packages/Roslynator.Analyzers/) contains only analyzers.
+* The [Roslynator 2019](http://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2019) VS extension includes analyzers, refactorings, and code fixes for CS diagnostics.
+* The [Roslynator.Analyzers](http://www.nuget.org/packages/Roslynator.Analyzers/) package includes analyzers only.
 
 ## Documentation
 

--- a/src/VisualStudio/Overview.md
+++ b/src/VisualStudio/Overview.md
@@ -1,22 +1,22 @@
 ## Overview
 
-* A collection of 500+ analyzers, refactorings and fixes for C#, powered by [Roslyn](https://github.com/dotnet/roslyn).
+* A collection of 500+ analyzers, refactorings, and fixes for C#, powered by [Roslyn](https://github.com/dotnet/roslyn).
 * [Project website](https://github.com/dotnet/roslynator)
 * [List of analyzers](https://josefpihrt.github.io/docs/roslynator/analyzers)
 * [List of refactorings](https://josefpihrt.github.io/docs/roslynator/refactorings)
 * [List of code fixes for CS diagnostics](https://josefpihrt.github.io/docs/roslynator/fixes)
 * [Release notes](https://github.com/dotnet/roslynator/blob/main/ChangeLog.md)
 
-IMPORTANT: Analyzers will be removed from Roslynator extension in the next major release.
-As a replacement, use Roslynator NuGet packages (e.g. [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
+IMPORTANT: Analyzers will be removed from the Roslynator extension in the next major release.
+Use Roslynator NuGet packages instead (for example, [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
 
 ## Donation
 
-Although Roslynator is free of charge, any [donation](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BX85UA346VTN6) is welcome and supports further development.
+Although Roslynator is free of charge, [donations](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BX85UA346VTN6) are welcome and support further development.
 
 ## Related Products
 
-* Package [Roslynator.Analyzers](http://www.nuget.org/packages/Roslynator.Analyzers/) contains only analyzers.
+* The [Roslynator.Analyzers](http://www.nuget.org/packages/Roslynator.Analyzers/) package includes analyzers only.
 
 ## Documentation
 

--- a/src/VisualStudioCode/package/README.md
+++ b/src/VisualStudioCode/package/README.md
@@ -1,26 +1,25 @@
 # Roslynator for Visual Studio Code
 
-A collection of 500+ [analyzers](https://josefpihrt.github.io/docs/roslynator/analyzers), [refactorings](https://josefpihrt.github.io/docs/roslynator/refactorings) and [fixes](https://josefpihrt.github.io/docs/roslynator/fixes) for C#, powered by [Roslyn](https://github.com/dotnet/roslyn).
+A collection of 500+ [analyzers](https://josefpihrt.github.io/docs/roslynator/analyzers), [refactorings](https://josefpihrt.github.io/docs/roslynator/refactorings), and [fixes](https://josefpihrt.github.io/docs/roslynator/fixes) for C#, powered by [Roslyn](https://github.com/dotnet/roslyn).
 
 IMPORTANT: Analyzers will be removed from Roslynator for VS Code in the next major release.
-It's recommended to use Roslynator NuGet packages (e.g. [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)) instead.
+Use Roslynator NuGet packages instead (for example, [Roslynator.Analyzers](https://www.nuget.org/packages/roslynator.analyzers)).
 
-## Prerequsities
+## Prerequisites
 
-Prerequisite for this extension is to use OmniSharp:
+This extension requires OmniSharp:
 
 - Set VS Code setting `dotnet.server.useOmnisharp` to `true`
 - Disable extension **C# Dev Kit** (if installed)
 
-NOTE: After each installation, Roslynator updates `omnisharp.json` to include references to Roslynator DLLs.
+NOTE: After each installation, Roslynator updates `omnisharp.json` with references to its DLLs.
 
-[C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) currently does not support loading Roslyn features from an extension (see related [issue](https://github.com/dotnet/vscode-csharp/issues/6790)), which means that this extension won't work with C# Dev Kit.
-As an alternative, it's possible to use NuGet packages that provide [refactorings](https://www.nuget.org/packages/roslynator.refactorings)
- and [code fixes for compiler diagnostics](https://www.nuget.org/packages/roslynator.codefixes).
+[C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) does not currently support loading Roslyn features from an extension (see related [issue](https://github.com/dotnet/vscode-csharp/issues/6790)), so this extension does not work with C# Dev Kit.
+As an alternative, use NuGet packages that provide [refactorings](https://www.nuget.org/packages/roslynator.refactorings) and [code fixes for compiler diagnostics](https://www.nuget.org/packages/roslynator.codefixes).
 
 ## Configuration
 
-Use EditorConfig file to configure analyzers, refactorings and compiler diagnostic fixes.
+Use an EditorConfig file to configure analyzers, refactorings, and compiler diagnostic fixes.
 
 ```editorconfig
 # Set severity for all analyzers that are enabled by default (https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2022#set-rule-severity-of-multiple-analyzer-rules-at-once-in-an-editorconfig-file)
@@ -46,13 +45,13 @@ roslynator_compiler_diagnostic_fixes.enabled = true|false
 roslynator_compiler_diagnostic_fix.<COMPILER_DIAGNOSTIC_ID>.enabled = true|false
 ```
 
-Full list of available options is [here](https://josefpihrt.github.io/docs/roslynator/configuration)
+See the [full list of configuration options](https://josefpihrt.github.io/docs/roslynator/configuration).
 
 ## Default Configuration
 
-If you want to configure Roslynator on a user-wide basis you have to use Roslynator config file.
+To configure Roslynator for all projects on your machine, use a `.roslynatorconfig` file.
 
-How to open config file:
+To open the config file:
 
 1) Press Ctrl + Shift + P
 2) Type "roslynator"
@@ -60,8 +59,8 @@ How to open config file:
 
 ## Location of Configuration File
 
-Configuration file is located at `%LOCALAPPDATA%/JosefPihrt/Roslynator/.roslynatorconfig`.
-Location of `%LOCALAPPDATA%` depends on the operating system:
+The configuration file is located at `%LOCALAPPDATA%/JosefPihrt/Roslynator/.roslynatorconfig`.
+The value of `%LOCALAPPDATA%` depends on the operating system:
 
 | OS | Path |
 | -------- | ------- |
@@ -69,7 +68,7 @@ Location of `%LOCALAPPDATA%` depends on the operating system:
 | Linux | `/home/<USERNAME>/.local/share/JosefPihrt/Roslynator/.roslynatorconfig` |
 | OSX | `/Users/<USERNAME>/.local/share/JosefPihrt/Roslynator/.roslynatorconfig` |
 
-Default configuration is loaded once when IDE starts. Therefore, it may be necessary to restart IDE for changes to take effect.
+Default configuration is loaded once when the IDE starts. Therefore, it may be necessary to restart the IDE for changes to take effect.
 
 ## Requirements
 
@@ -77,9 +76,9 @@ This extension requires [C# for Visual Studio Code](https://marketplace.visualst
 
 ## Donation
 
-Although Roslynator products are free of charge, any [donation](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BX85UA346VTN6) is welcome and supports further development.
+Although Roslynator is free of charge, [donations](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BX85UA346VTN6) are welcome and support further development.
 
 ## Thanks
 
-* Thanks to [Pekka Savolainen](https://github.com/savpek) who pioneered the way for Roslyn analyzers on Visual Studio Code.
-* Thanks to [Adrian Wilczynski](https://github.com/AdrianWilczynski) who added several great [PRs](https://github.com/dotnet/roslynator/pulls?q=author%3AAdrianWilczynski).
+* Thanks to [Pekka Savolainen](https://github.com/savpek), who pioneered Roslyn analyzers on Visual Studio Code.
+* Thanks to [Adrian Wilczynski](https://github.com/AdrianWilczynski) for several great [PRs](https://github.com/dotnet/roslynator/pulls?q=author%3AAdrianWilczynski).

--- a/src/Workspaces.Core/docs/NuGetReadme.md
+++ b/src/Workspaces.Core/docs/NuGetReadme.md
@@ -1,6 +1,6 @@
 # Roslynator.Workspaces.Core
 
-This package extends functionality of package [Microsoft.CodeAnalysis.Workspaces.Common](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.Common).
+This package extends the functionality of the [Microsoft.CodeAnalysis.Workspaces.Common](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.Common) package.
 
 ## Feedback
 


### PR DESCRIPTION
## Summary
- Polish grammar and rephrasing across README, VS Code README, Visual Studio overviews, NuGet readmes, CLI generator fragments, and CONTRIBUTING.md
- Add inline code formatting for technical identifiers in prose (flags, filenames, diagnostic ID patterns, EditorConfig)
- Update outdated GitHub URLs (`josefpihrt/orang`, `josefpihrt/Wordb`, sponsors username); changelogs and `JosefPihrt/Roslynator` config paths are unchanged

## Test plan
- [ ] Review README and VS Code marketplace README for accuracy
- [ ] Spot-check NuGet readme rendering on nuget.org after next package publish
- [ ] Verify CLI documentation generator output if regenerated from `data/*.md` fragments


Made with [Cursor](https://cursor.com)