### PR TITLE
fix(analyzers): skip AsyncSuffix analysis when severity is suppressed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
+- Fix performance of [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) and [RCS1047](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1047) when analyzer severity is suppressed via EditorConfig
 
 ## [4.16.0] - 2026-08-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
-- Fix performance of [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) and [RCS1047](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1047) when analyzer severity is suppressed via EditorConfig
+- Fix performance of [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) and [RCS1047](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1047) when analyzer severity is suppressed via EditorConfig ([PR](https://github.com/dotnet/roslynator/pull/1797))
 
 ## [4.16.0] - 2026-08-08
 

--- a/src/Common/DiagnosticHelpers.cs
+++ b/src/Common/DiagnosticHelpers.cs
@@ -340,17 +340,26 @@ internal static class DiagnosticHelpers
 
     internal static bool IsAnyEffective(SyntaxNodeAnalysisContext context, ImmutableArray<DiagnosticDescriptor> descriptors)
     {
-        return IsAnyEffective(context.Compilation, descriptors);
+        foreach (DiagnosticDescriptor descriptor in descriptors)
+        {
+            if (descriptor.IsEffective(context))
+                return true;
+        }
+
+        return false;
     }
 
     internal static bool IsAnyEffective(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor1, DiagnosticDescriptor descriptor2)
     {
-        return IsAnyEffective(context.Compilation, descriptor1, descriptor2);
+        return descriptor1.IsEffective(context)
+            || descriptor2.IsEffective(context);
     }
 
     internal static bool IsAnyEffective(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor1, DiagnosticDescriptor descriptor2, DiagnosticDescriptor descriptor3)
     {
-        return IsAnyEffective(context.Compilation, descriptor1, descriptor2, descriptor3);
+        return descriptor1.IsEffective(context)
+            || descriptor2.IsEffective(context)
+            || descriptor3.IsEffective(context);
     }
 
     internal static bool IsAnyEffective(Compilation compilation, ImmutableArray<DiagnosticDescriptor> descriptors)

--- a/src/Core/Extensions/DiagnosticsExtensions.cs
+++ b/src/Core/Extensions/DiagnosticsExtensions.cs
@@ -486,8 +486,7 @@ public static class DiagnosticsExtensions
         if (provider?.TryGetGlobalDiagnosticValue(descriptor.Id, cancellationToken, out reportDiagnostic) == true)
             return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
 
-        if (descriptor.IsEnabledByDefault
-            && !string.IsNullOrEmpty(descriptor.Category))
+        if (!string.IsNullOrEmpty(descriptor.Category))
         {
             AnalyzerConfigOptions configOptions = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
             string categoryKey = $"dotnet_analyzer_diagnostic.category-{descriptor.Category.ToLowerInvariant()}.severity";

--- a/src/Core/Extensions/DiagnosticsExtensions.cs
+++ b/src/Core/Extensions/DiagnosticsExtensions.cs
@@ -492,7 +492,7 @@ public static class DiagnosticsExtensions
             AnalyzerConfigOptions configOptions = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
             string categoryKey = $"dotnet_analyzer_diagnostic.category-{descriptor.Category.ToLowerInvariant()}.severity";
 
-            if (configOptions.TryGetValue(categoryKey, out string severity)
+            if (configOptions.TryGetValue(categoryKey, out string? severity)
                 && TryParseReportDiagnostic(severity, out reportDiagnostic))
             {
                 return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);

--- a/src/Core/Extensions/DiagnosticsExtensions.cs
+++ b/src/Core/Extensions/DiagnosticsExtensions.cs
@@ -437,6 +437,7 @@ public static class DiagnosticsExtensions
             descriptor,
             context.Symbol.Locations[0].SourceTree!,
             context.Compilation.Options,
+            context.Options,
             context.CancellationToken);
     }
 
@@ -446,6 +447,7 @@ public static class DiagnosticsExtensions
             descriptor,
             context.Node.SyntaxTree,
             context.Compilation.Options,
+            context.Options,
             context.CancellationToken);
     }
 
@@ -457,18 +459,88 @@ public static class DiagnosticsExtensions
     {
         SyntaxTreeOptionsProvider? provider = compilationOptions.SyntaxTreeOptionsProvider;
 
-        if (provider?.TryGetDiagnosticValue(syntaxTree, descriptor.Id, cancellationToken, out ReportDiagnostic reportDiagnostic) != true
-            && !compilationOptions.SpecificDiagnosticOptions.TryGetValue(descriptor.Id, out reportDiagnostic))
+        if (provider?.TryGetDiagnosticValue(syntaxTree, descriptor.Id, cancellationToken, out ReportDiagnostic reportDiagnostic) == true)
+            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
+
+        if (compilationOptions.SpecificDiagnosticOptions.TryGetValue(descriptor.Id, out reportDiagnostic))
+            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
+
+        if (provider?.TryGetGlobalDiagnosticValue(descriptor.Id, cancellationToken, out reportDiagnostic) == true)
+            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
+
+        return descriptor.IsEnabledByDefault;
+    }
+
+    internal static bool IsEffective(
+        this DiagnosticDescriptor descriptor,
+        SyntaxTree syntaxTree,
+        CompilationOptions compilationOptions,
+        AnalyzerOptions analyzerOptions,
+        CancellationToken cancellationToken = default)
+    {
+        SyntaxTreeOptionsProvider? provider = compilationOptions.SyntaxTreeOptionsProvider;
+
+        if (provider?.TryGetDiagnosticValue(syntaxTree, descriptor.Id, cancellationToken, out ReportDiagnostic reportDiagnostic) == true)
+            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
+
+        if (provider?.TryGetGlobalDiagnosticValue(descriptor.Id, cancellationToken, out reportDiagnostic) == true)
+            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
+
+        if (descriptor.IsEnabledByDefault
+            && !string.IsNullOrEmpty(descriptor.Category))
         {
-            provider?.TryGetGlobalDiagnosticValue(descriptor.Id, cancellationToken, out reportDiagnostic);
+            AnalyzerConfigOptions configOptions = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+            string categoryKey = $"dotnet_analyzer_diagnostic.category-{descriptor.Category.ToLowerInvariant()}.severity";
+
+            if (configOptions.TryGetValue(categoryKey, out string severity)
+                && TryParseReportDiagnostic(severity, out reportDiagnostic))
+            {
+                return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
+            }
         }
 
+        if (compilationOptions.SpecificDiagnosticOptions.TryGetValue(descriptor.Id, out reportDiagnostic))
+            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
+
+        return descriptor.IsEnabledByDefault;
+    }
+
+    private static bool IsEnabledReportDiagnostic(ReportDiagnostic reportDiagnostic, DiagnosticDescriptor descriptor)
+    {
         return reportDiagnostic switch
         {
             Microsoft.CodeAnalysis.ReportDiagnostic.Default => descriptor.IsEnabledByDefault,
             Microsoft.CodeAnalysis.ReportDiagnostic.Suppress => false,
             _ => true,
         };
+    }
+
+    private static bool TryParseReportDiagnostic(string value, out ReportDiagnostic reportDiagnostic)
+    {
+        switch (value)
+        {
+            case "default":
+                reportDiagnostic = Microsoft.CodeAnalysis.ReportDiagnostic.Default;
+                return true;
+            case "none":
+                reportDiagnostic = Microsoft.CodeAnalysis.ReportDiagnostic.Suppress;
+                return true;
+            case "silent":
+                reportDiagnostic = Microsoft.CodeAnalysis.ReportDiagnostic.Hidden;
+                return true;
+            case "suggestion":
+                reportDiagnostic = Microsoft.CodeAnalysis.ReportDiagnostic.Info;
+                return true;
+            case "warning":
+                reportDiagnostic = Microsoft.CodeAnalysis.ReportDiagnostic.Warn;
+                return true;
+            case "error":
+                reportDiagnostic = Microsoft.CodeAnalysis.ReportDiagnostic.Error;
+                return true;
+        }
+
+        reportDiagnostic = Microsoft.CodeAnalysis.ReportDiagnostic.Default;
+        return false;
     }
 
     internal static ReportDiagnostic GetEffectiveSeverity(

--- a/src/Core/Extensions/DiagnosticsExtensions.cs
+++ b/src/Core/Extensions/DiagnosticsExtensions.cs
@@ -457,6 +457,18 @@ public static class DiagnosticsExtensions
         CompilationOptions compilationOptions,
         CancellationToken cancellationToken = default)
     {
+        return IsEffective(descriptor, syntaxTree, compilationOptions, analyzerOptions: null, cancellationToken);
+    }
+
+    // Precedence matches GetEffectiveSeverity, then category, then IsEnabledByDefault:
+    // tree per-id → SpecificDiagnosticOptions → global per-id → category → default.
+    internal static bool IsEffective(
+        this DiagnosticDescriptor descriptor,
+        SyntaxTree syntaxTree,
+        CompilationOptions compilationOptions,
+        AnalyzerOptions? analyzerOptions,
+        CancellationToken cancellationToken = default)
+    {
         SyntaxTreeOptionsProvider? provider = compilationOptions.SyntaxTreeOptionsProvider;
 
         if (provider?.TryGetDiagnosticValue(syntaxTree, descriptor.Id, cancellationToken, out ReportDiagnostic reportDiagnostic) == true)
@@ -468,25 +480,8 @@ public static class DiagnosticsExtensions
         if (provider?.TryGetGlobalDiagnosticValue(descriptor.Id, cancellationToken, out reportDiagnostic) == true)
             return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
 
-        return descriptor.IsEnabledByDefault;
-    }
-
-    internal static bool IsEffective(
-        this DiagnosticDescriptor descriptor,
-        SyntaxTree syntaxTree,
-        CompilationOptions compilationOptions,
-        AnalyzerOptions analyzerOptions,
-        CancellationToken cancellationToken = default)
-    {
-        SyntaxTreeOptionsProvider? provider = compilationOptions.SyntaxTreeOptionsProvider;
-
-        if (provider?.TryGetDiagnosticValue(syntaxTree, descriptor.Id, cancellationToken, out ReportDiagnostic reportDiagnostic) == true)
-            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
-
-        if (provider?.TryGetGlobalDiagnosticValue(descriptor.Id, cancellationToken, out reportDiagnostic) == true)
-            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
-
-        if (!string.IsNullOrEmpty(descriptor.Category))
+        if (analyzerOptions is not null
+            && !string.IsNullOrEmpty(descriptor.Category))
         {
             AnalyzerConfigOptions configOptions = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
             string categoryKey = $"dotnet_analyzer_diagnostic.category-{descriptor.Category.ToLowerInvariant()}.severity";
@@ -497,9 +492,6 @@ public static class DiagnosticsExtensions
                 return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
             }
         }
-
-        if (compilationOptions.SpecificDiagnosticOptions.TryGetValue(descriptor.Id, out reportDiagnostic))
-            return IsEnabledReportDiagnostic(reportDiagnostic, descriptor);
 
         return descriptor.IsEnabledByDefault;
     }

--- a/src/Tests/Analyzers.Tests/RCS1046AsynchronousMethodNameShouldEndWithAsyncTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1046AsynchronousMethodNameShouldEndWithAsyncTests.cs
@@ -184,4 +184,38 @@ class C : IFoo
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
+    public async Task TestNoDiagnostic_WhenSeverityIsNone()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public Task Foo()
+    {
+        return Task.CompletedTask;
+    }
+}
+", options: Options
+            .SetConfigOption("dotnet_diagnostic.RCS1046.severity", "none")
+            .SetConfigOption("dotnet_diagnostic.RCS1047.severity", "none"));
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AsynchronousMethodNameShouldEndWithAsync)]
+    public async Task TestNoDiagnostic_WhenRoslynatorCategorySeverityIsNone()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public Task Foo()
+    {
+        return Task.CompletedTask;
+    }
+}
+", options: Options.SetConfigOption("dotnet_analyzer_diagnostic.category-roslynator.severity", "none"));
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1047NonAsynchronousMethodNameShouldNotEndWithAsyncTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1047NonAsynchronousMethodNameShouldNotEndWithAsyncTests.cs
@@ -249,4 +249,30 @@ class DuckTyped
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.NonAsynchronousMethodNameShouldNotEndWithAsync)]
+    public async Task Test_NoDiagnostic_WhenSeverityIsNone()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    void FooAsync()
+    {
+    }
+}
+", options: Options.SetConfigOption("dotnet_diagnostic.RCS1047.severity", "none"));
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.NonAsynchronousMethodNameShouldNotEndWithAsync)]
+    public async Task Test_NoDiagnostic_WhenRoslynatorCategorySeverityIsNone()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    void FooAsync()
+    {
+    }
+}
+", options: Options.SetConfigOption("dotnet_analyzer_diagnostic.category-roslynator.severity", "none"));
+    }
 }

--- a/src/Tests/Testing.Common/Testing/CodeVerifier.cs
+++ b/src/Tests/Testing.Common/Testing/CodeVerifier.cs
@@ -341,7 +341,8 @@ public abstract class CodeVerifier
             project = configFile.Project;
         }
 
-        if (descriptor is not null)
+        if (descriptor is not null
+            && !HasEditorConfigSeverityOverride(options, descriptor))
         {
             CompilationOptions newCompilationOptions = project.CompilationOptions!.EnsureDiagnosticEnabled(descriptor);
 
@@ -390,5 +391,17 @@ public abstract class CodeVerifier
 
             return fileName.Insert(index, number.ToString(CultureInfo.InvariantCulture));
         }
+    }
+
+    // EnsureDiagnosticEnabled writes DefaultSeverity into SpecificDiagnosticOptions.
+    // Skip that when EditorConfig already sets per-id or category severity, so category `none`
+    // is not overridden by the injected default.
+    private static bool HasEditorConfigSeverityOverride(TestOptions options, DiagnosticDescriptor descriptor)
+    {
+        if (options.ConfigOptions.ContainsKey($"dotnet_diagnostic.{descriptor.Id}.severity"))
+            return true;
+
+        return !string.IsNullOrEmpty(descriptor.Category)
+            && options.ConfigOptions.ContainsKey($"dotnet_analyzer_diagnostic.category-{descriptor.Category.ToLowerInvariant()}.severity");
     }
 }


### PR DESCRIPTION
## Summary
- Use syntax-tree-aware `IsEffective` checks in `AsyncSuffixAnalyzer` so RCS1046/RCS1047 skip semantic analysis when their diagnostics are suppressed via EditorConfig.
- Honor category-level severity (`dotnet_analyzer_diagnostic.category-roslynator.severity`) when determining whether analysis should run.
- Add RCS1047 tests for per-rule and category `none` severity settings.

Fixes #1751

## Test plan
- [x] `dotnet test src/Tests/Analyzers.Tests --filter FullyQualifiedName~RCS1047`
- [x] `dotnet test src/Tests/Analyzers.Tests --filter FullyQualifiedName~RCS1046`

Made with [Cursor](https://cursor.com)