### PR TITLE
fix(analyzers): ignore partial type parts for RCS1060

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
+- Fix analyzer [RCS1060](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1060) to ignore multiple partial declarations of the same type in one file
 
 ## [4.16.0] - 2026-08-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
-- Fix analyzer [RCS1060](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1060) to ignore multiple partial declarations of the same type in one file
+- Fix analyzer [RCS1060](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1060) to ignore multiple partial declarations of the same type in one file ([PR](https://github.com/dotnet/roslynator/pull/1798))
 
 ## [4.16.0] - 2026-08-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
-- Fix analyzer [RCS1060](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1060) to ignore multiple partial declarations of the same type in one file ([PR](https://github.com/dotnet/roslynator/pull/1798))
+- Fix analyzer [RCS1060](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1060) to not report a file that contains only multiple partial declarations of the same type ([PR](https://github.com/dotnet/roslynator/pull/1798))
 
 ## [4.16.0] - 2026-08-08
 

--- a/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -46,9 +47,9 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
         MemberDeclarationSyntax firstTypeDeclaration = null;
         var isFirstReported = false;
 
-        Analyze(compilationUnitMembers);
+        Analyze(compilationUnitMembers, new HashSet<string>());
 
-        void Analyze(SyntaxList<MemberDeclarationSyntax> members)
+        void Analyze(SyntaxList<MemberDeclarationSyntax> members, HashSet<string> declaredTypeNames)
         {
             foreach (MemberDeclarationSyntax member in members)
             {
@@ -58,7 +59,7 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                 if (member is NamespaceDeclarationSyntax namespaceDeclaration)
 #endif
                 {
-                    Analyze(namespaceDeclaration.Members);
+                    Analyze(namespaceDeclaration.Members, new HashSet<string>());
                 }
                 else if (SyntaxFacts.IsTypeDeclaration(member.Kind())
 #if ROSLYN_4_4
@@ -66,6 +67,22 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
 #endif
                     )
                 {
+                    SyntaxToken identifier = CSharpUtility.GetIdentifier(member);
+
+                    if (identifier == default)
+                        continue;
+
+                    string typeName = identifier.ValueText;
+
+                    if (declaredTypeNames.Contains(typeName)
+                        && member.Modifiers.Contains(SyntaxKind.PartialKeyword))
+                    {
+                        continue;
+                    }
+
+                    if (!declaredTypeNames.Contains(typeName))
+                        declaredTypeNames.Add(typeName);
+
                     if (firstTypeDeclaration is null)
                     {
                         firstTypeDeclaration = member;

--- a/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
@@ -47,9 +47,9 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
         MemberDeclarationSyntax firstTypeDeclaration = null;
         var isFirstReported = false;
 
-        Analyze(compilationUnitMembers, new HashSet<string>());
+        Analyze(compilationUnitMembers, new HashSet<(string Name, int Arity)>());
 
-        void Analyze(SyntaxList<MemberDeclarationSyntax> members, HashSet<string> declaredTypeNames)
+        void Analyze(SyntaxList<MemberDeclarationSyntax> members, HashSet<(string Name, int Arity)> declaredTypes)
         {
             foreach (MemberDeclarationSyntax member in members)
             {
@@ -59,7 +59,7 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                 if (member is NamespaceDeclarationSyntax namespaceDeclaration)
 #endif
                 {
-                    Analyze(namespaceDeclaration.Members, new HashSet<string>());
+                    Analyze(namespaceDeclaration.Members, new HashSet<(string Name, int Arity)>());
                 }
                 else if (SyntaxFacts.IsTypeDeclaration(member.Kind())
 #if ROSLYN_4_4
@@ -72,16 +72,14 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                     if (identifier == default)
                         continue;
 
-                    string typeName = identifier.ValueText;
+                    int arity = CSharpUtility.GetTypeParameterList(member)?.Parameters.Count ?? 0;
+                    var typeKey = (identifier.ValueText, arity);
 
-                    if (declaredTypeNames.Contains(typeName)
+                    if (!declaredTypes.Add(typeKey)
                         && member.Modifiers.Contains(SyntaxKind.PartialKeyword))
                     {
                         continue;
                     }
-
-                    if (!declaredTypeNames.Contains(typeName))
-                        declaredTypeNames.Add(typeName);
 
                     if (firstTypeDeclaration is null)
                     {

--- a/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -44,6 +43,9 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
         if (ContainsSingleNamespaceWithSingleNonNamespaceMember(compilationUnitMembers))
             return;
 
+        if (ContainsOnlyPartialDeclarationsOfSameType(compilationUnitMembers))
+            return;
+
         MemberDeclarationSyntax firstTypeDeclaration = null;
         var isFirstReported = false;
 
@@ -51,10 +53,6 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
 
         void Analyze(SyntaxList<MemberDeclarationSyntax> members)
         {
-            (string Name, int Arity) firstTypeKey = default;
-            var hasFirstTypeKey = false;
-            HashSet<(string Name, int Arity)> declaredTypes = null;
-
             foreach (MemberDeclarationSyntax member in members)
             {
 #if ROSLYN_4_0
@@ -71,38 +69,6 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
 #endif
                     )
                 {
-                    SyntaxToken identifier = CSharpUtility.GetIdentifier(member);
-
-                    if (identifier == default)
-                        continue;
-
-                    int arity = CSharpUtility.GetTypeParameterList(member)?.Parameters.Count ?? 0;
-                    (string Name, int Arity) typeKey = (identifier.ValueText, arity);
-
-                    if (declaredTypes is not null)
-                    {
-                        if (!declaredTypes.Add(typeKey)
-                            && member.Modifiers.Contains(SyntaxKind.PartialKeyword))
-                        {
-                            continue;
-                        }
-                    }
-                    else if (!hasFirstTypeKey)
-                    {
-                        firstTypeKey = typeKey;
-                        hasFirstTypeKey = true;
-                    }
-                    else if (typeKey == firstTypeKey
-                        && member.Modifiers.Contains(SyntaxKind.PartialKeyword))
-                    {
-                        continue;
-                    }
-                    else
-                    {
-                        declaredTypes = new HashSet<(string Name, int Arity)>() { firstTypeKey };
-                        declaredTypes.Add(typeKey);
-                    }
-
                     if (firstTypeDeclaration is null)
                     {
                         firstTypeDeclaration = member;
@@ -147,5 +113,47 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
         }
 
         return false;
+    }
+
+    private static bool ContainsOnlyPartialDeclarationsOfSameType(SyntaxList<MemberDeclarationSyntax> members)
+    {
+#if ROSLYN_4_0
+        if (members.SingleOrDefault(shouldThrow: false) is BaseNamespaceDeclarationSyntax namespaceDeclaration)
+#else
+        if (members.SingleOrDefault(shouldThrow: false) is NamespaceDeclarationSyntax namespaceDeclaration)
+#endif
+            members = namespaceDeclaration.Members;
+
+        string name = null;
+        int arity = -1;
+
+        foreach (MemberDeclarationSyntax member in members)
+        {
+            if (!SyntaxFacts.IsTypeDeclaration(member.Kind()))
+                return false;
+
+            if (!member.Modifiers.Contains(SyntaxKind.PartialKeyword))
+                return false;
+
+            SyntaxToken identifier = CSharpUtility.GetIdentifier(member);
+
+            if (identifier == default)
+                return false;
+
+            int currentArity = CSharpUtility.GetTypeParameterList(member)?.Parameters.Count ?? 0;
+
+            if (name is null)
+            {
+                name = identifier.ValueText;
+                arity = currentArity;
+            }
+            else if (name != identifier.ValueText
+                || arity != currentArity)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
@@ -73,7 +73,7 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                         continue;
 
                     int arity = CSharpUtility.GetTypeParameterList(member)?.Parameters.Count ?? 0;
-                    var typeKey = (identifier.ValueText, arity);
+                    (string Name, int Arity) typeKey = (identifier.ValueText, arity);
 
                     if (!declaredTypes.Add(typeKey)
                         && member.Modifiers.Contains(SyntaxKind.PartialKeyword))

--- a/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
@@ -99,7 +99,7 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                     }
                     else
                     {
-                        declaredTypes = new HashSet<(string Name, int Arity)> { firstTypeKey };
+                        declaredTypes = new HashSet<(string Name, int Arity)>() { firstTypeKey };
                         declaredTypes.Add(typeKey);
                     }
 

--- a/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
@@ -47,10 +47,14 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
         MemberDeclarationSyntax firstTypeDeclaration = null;
         var isFirstReported = false;
 
-        Analyze(compilationUnitMembers, new HashSet<(string Name, int Arity)>());
+        Analyze(compilationUnitMembers);
 
-        void Analyze(SyntaxList<MemberDeclarationSyntax> members, HashSet<(string Name, int Arity)> declaredTypes)
+        void Analyze(SyntaxList<MemberDeclarationSyntax> members)
         {
+            (string Name, int Arity) firstTypeKey = default;
+            var hasFirstTypeKey = false;
+            HashSet<(string Name, int Arity)> declaredTypes = null;
+
             foreach (MemberDeclarationSyntax member in members)
             {
 #if ROSLYN_4_0
@@ -59,7 +63,7 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                 if (member is NamespaceDeclarationSyntax namespaceDeclaration)
 #endif
                 {
-                    Analyze(namespaceDeclaration.Members, new HashSet<(string Name, int Arity)>());
+                    Analyze(namespaceDeclaration.Members);
                 }
                 else if (SyntaxFacts.IsTypeDeclaration(member.Kind())
 #if ROSLYN_4_4
@@ -75,10 +79,28 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                     int arity = CSharpUtility.GetTypeParameterList(member)?.Parameters.Count ?? 0;
                     (string Name, int Arity) typeKey = (identifier.ValueText, arity);
 
-                    if (!declaredTypes.Add(typeKey)
+                    if (declaredTypes is not null)
+                    {
+                        if (!declaredTypes.Add(typeKey)
+                            && member.Modifiers.Contains(SyntaxKind.PartialKeyword))
+                        {
+                            continue;
+                        }
+                    }
+                    else if (!hasFirstTypeKey)
+                    {
+                        firstTypeKey = typeKey;
+                        hasFirstTypeKey = true;
+                    }
+                    else if (typeKey == firstTypeKey
                         && member.Modifiers.Contains(SyntaxKind.PartialKeyword))
                     {
                         continue;
+                    }
+                    else
+                    {
+                        declaredTypes = new HashSet<(string Name, int Arity)> { firstTypeKey };
+                        declaredTypes.Add(typeKey);
                     }
 
                     if (firstTypeDeclaration is null)

--- a/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
@@ -81,4 +81,64 @@ namespace N
 }
 """);
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_PartialClassSameFile_NoDiagnostic()
+    {
+        await VerifyNoDiagnosticAsync("""
+using System;
+
+namespace N
+{
+    public partial class Foo
+    {
+    }
+
+    public partial class Foo : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}
+""");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_PartialClassWithDistinctType_Reports()
+    {
+        await VerifyDiagnosticAsync("""
+namespace N
+{
+    public partial class [|Foo|]
+    {
+    }
+
+    public class [|Bar|]
+    {
+    }
+}
+""");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_FileScopedNamespace_PartialClassSameFile_NoDiagnostic()
+    {
+        await VerifyNoDiagnosticAsync("""
+using System;
+
+namespace N;
+
+public partial class Foo
+{
+}
+
+public partial class Foo : IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+""");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
@@ -160,7 +160,7 @@ namespace N
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
-    public async Task Test_PartialClassRepeatedAfterDistinctType_ReportsOncePerType()
+    public async Task Test_PartialClassRepeatedAfterDistinctType_Reports()
     {
         await VerifyDiagnosticAsync("""
 namespace N
@@ -173,7 +173,7 @@ namespace N
     {
     }
 
-    public partial class Foo
+    public partial class [|Foo|]
     {
     }
 }
@@ -195,6 +195,62 @@ namespace N
     }
 
     public partial class [|Foo|]<T, U>
+    {
+    }
+}
+""");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_PartialClassWithoutNamespace_NoDiagnostic()
+    {
+        await VerifyNoDiagnosticAsync("""
+using System;
+
+public partial class Foo
+{
+}
+
+public partial class Foo : IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+""");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_PartialClassInTwoNamespaces_Reports()
+    {
+        await VerifyDiagnosticAsync("""
+namespace N1
+{
+    public partial class [|Foo|]
+    {
+    }
+}
+
+namespace N2
+{
+    public partial class [|Foo|]
+    {
+    }
+}
+""");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_PartialClassesWithDifferentName_Reports()
+    {
+        await VerifyDiagnosticAsync("""
+namespace N
+{
+    public partial class [|Foo|]
+    {
+    }
+
+    public partial class [|Bar|]
     {
     }
 }

--- a/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
@@ -160,6 +160,27 @@ namespace N
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_PartialClassRepeatedAfterDistinctType_ReportsOncePerType()
+    {
+        await VerifyDiagnosticAsync("""
+namespace N
+{
+    public partial class [|Foo|]
+    {
+    }
+
+    public class [|Bar|]
+    {
+    }
+
+    public partial class Foo
+    {
+    }
+}
+""");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
     public async Task Test_PartialClassesWithDifferentArity_Reports()
     {
         await VerifyDiagnosticAsync("""

--- a/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
@@ -141,4 +141,42 @@ public partial class Foo : IDisposable
 }
 """);
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_PartialGenericClassSameFile_NoDiagnostic()
+    {
+        await VerifyNoDiagnosticAsync("""
+namespace N
+{
+    public partial class Foo<T>
+    {
+    }
+
+    public partial class Foo<T>
+    {
+    }
+}
+""");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_PartialClassesWithDifferentArity_Reports()
+    {
+        await VerifyDiagnosticAsync("""
+namespace N
+{
+    public partial class [|Foo|]
+    {
+    }
+
+    public partial class [|Foo|]<T>
+    {
+    }
+
+    public partial class [|Foo|]<T, U>
+    {
+    }
+}
+""");
+    }
 }


### PR DESCRIPTION
## Summary
- Group type declarations by name within each namespace scope when counting types in a file.
- Skip additional `partial` declarations of an already-seen type so multiple partial parts of the same type do not trigger RCS1060.
- Add tests for the issue repro, partial + distinct type regression, and file-scoped namespace.

Fixes #1779

## Test plan
- [x] `dotnet test src/Tests/Analyzers.Tests --filter FullyQualifiedName~RCS1060`

Made with [Cursor](https://cursor.com)