### PR TITLE
[5.0] Fix RCS1263 and RCS1139 for C# 14 extension block XmlDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
 - [CLI] Fix `generate-doc` to omit internal interfaces from type declarations and the Implements section ([PR](https://github.com/dotnet/roslynator/pull/1801))
 
+### Fixed
+
+- Fix analyzers [RCS1263](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1263) and [RCS1139](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1139) for C# 14 extension block documentation
+
 ## [4.16.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix analyzers [RCS1263](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1263) and [RCS1139](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1139) for C# 14 extension block documentation
+- Fix analyzers [RCS1263](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1263) and [RCS1139](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1139) for C# 14 extension block documentation ([PR](https://github.com/dotnet/roslynator/pull/1799))
 
 ## [4.16.0] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop support for Visual Studio 2022 VSIX ([PR](https://github.com/dotnet/roslynator/pull/1787))
   - Pin last 4.x release ([Roslynator 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)) or use NuGet packages on Visual Studio 2022
 
+### Fixed
+
+- Fix analyzers [RCS1263](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1263) and [RCS1139](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1139) for C# 14 extension block documentation ([PR](https://github.com/dotnet/roslynator/pull/1799))
+
 ## [4.16.1] - 2026-08-16
 
 ### Fixed
@@ -47,10 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1231](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1231) to not report `CancellationToken` in sync methods returning `Task` ([PR](https://github.com/dotnet/roslynator/pull/1802))
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
 - [CLI] Fix `generate-doc` to omit internal interfaces from type declarations and the Implements section ([PR](https://github.com/dotnet/roslynator/pull/1801))
-
-### Fixed
-
-- Fix analyzers [RCS1263](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1263) and [RCS1139](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1139) for C# 14 extension block documentation ([PR](https://github.com/dotnet/roslynator/pull/1799))
 
 ## [4.16.0] - 2026-08-08
 

--- a/src/Analyzers/CSharp/Analysis/SingleLineDocumentationCommentTriviaAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/SingleLineDocumentationCommentTriviaAnalyzer.cs
@@ -185,13 +185,17 @@ public sealed class SingleLineDocumentationCommentTriviaAnalyzer : BaseDiagnosti
             return;
         }
 
+        SyntaxNode parent = documentationComment.ParentTrivia.Token.Parent;
+
         if (!containsSummaryElement
-            && !containsContentElement)
+            && !containsContentElement
+#if ROSLYN_5_0
+            && parent?.IsKind(SyntaxKind.ExtensionBlockDeclaration) != true
+#endif
+            )
         {
             ReportDiagnosticIfEffective(context, DiagnosticRules.AddSummaryElementToDocumentationComment, documentationComment);
         }
-
-        SyntaxNode parent = documentationComment.ParentTrivia.Token.Parent;
 
         bool invalidReference = DiagnosticRules.InvalidReferenceInDocumentationComment.IsEffective(context);
         bool orderParams = DiagnosticRules.OrderElementsInDocumentationComment.IsEffective(context);

--- a/src/CSharp/CSharp/CSharpUtility.cs
+++ b/src/CSharp/CSharp/CSharpUtility.cs
@@ -689,6 +689,10 @@ internal static class CSharpUtility
             case SyntaxKind.InterfaceDeclaration:
                 return ((TypeDeclarationSyntax)declaration).ParameterList;
 #endif
+#if ROSLYN_5_0
+            case SyntaxKind.ExtensionBlockDeclaration:
+                return ((ExtensionBlockDeclarationSyntax)declaration).ParameterList;
+#endif
             default:
                 return null;
         }
@@ -720,6 +724,10 @@ internal static class CSharpUtility
             case SyntaxKind.RecordStructDeclaration:
 #endif
                 return ((RecordDeclarationSyntax)declaration).TypeParameterList;
+#if ROSLYN_5_0
+            case SyntaxKind.ExtensionBlockDeclaration:
+                return ((ExtensionBlockDeclarationSyntax)declaration).TypeParameterList;
+#endif
             default:
                 return null;
         }

--- a/src/Tests/Analyzers.Tests/RCS1139AddSummaryElementToDocumentationCommentTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1139AddSummaryElementToDocumentationCommentTests.cs
@@ -50,4 +50,20 @@ partial class C
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AddSummaryElementToDocumentationComment)]
+    public async Task TestNoDiagnostic_ExtensionBlock_WithoutSummary()
+    {
+        await VerifyNoDiagnosticAsync("""
+static class C
+{
+    /// <param name="x">x</param>
+    /// <typeparam name="T">T</typeparam>
+    extension<T>(T x) where T : struct
+    {
+        public int M() => 0;
+    }
+}
+""");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1263InvalidReferenceInDocumentationCommentTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1263InvalidReferenceInDocumentationCommentTests.cs
@@ -223,4 +223,29 @@ static class C
 }
 """);
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.InvalidReferenceInDocumentationComment)]
+    public async Task Test_ExtensionBlock_InvalidParamName()
+    {
+        await VerifyDiagnosticAndFixAsync("""
+static class C
+{
+    /// <param name="[|missing|]"></param>
+    /// <typeparam name="T">T</typeparam>
+    extension<T>(T x) where T : struct
+    {
+        public int M() => 0;
+    }
+}
+""", """
+static class C
+{
+    /// <typeparam name="T">T</typeparam>
+    extension<T>(T x) where T : struct
+    {
+        public int M() => 0;
+    }
+}
+""");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1263InvalidReferenceInDocumentationCommentTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1263InvalidReferenceInDocumentationCommentTests.cs
@@ -207,4 +207,20 @@ public struct Foo(string value)
 }
 """);
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.InvalidReferenceInDocumentationComment)]
+    public async Task TestNoDiagnostic_ExtensionBlock_ParamAndTypeParam()
+    {
+        await VerifyNoDiagnosticAsync("""
+static class C
+{
+    /// <param name="x">x</param>
+    /// <typeparam name="T">T</typeparam>
+    extension<T>(T x) where T : struct
+    {
+        public int M() => 0;
+    }
+}
+""");
+    }
 }


### PR DESCRIPTION
## Summary

- Resolve extension block `<param>` and `<typeparam>` references in RCS1263 by handling `SyntaxKind.ExtensionBlockDeclaration` in `CSharpUtility.GetParameterList` / `GetTypeParameterList`
- Skip RCS1139 when documentation is attached to an extension block (summary is not valid there)
- Add analyzer tests for extension block documentation

Stacked on #1787 (`feature/roslyn-5`).

Fixes #1752

## Test plan

- [x] `dotnet test Tests/Analyzers.Tests/Analyzers.Tests.csproj --filter "ExtensionBlock"`
- [x] `dotnet build` with `RoslynVersion=roslyn5.0`, `roslyn4.7`, and `roslyn3.8` NuGet slices


Made with [Cursor](https://cursor.com)