### PR TITLE
fix(analyzers): preserve space after is in RCS1172 code fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
-- Fix code fix for [RCS1172](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1172) to preserve space after the `is` keyword
+- Fix code fix for [RCS1172](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1172) to preserve space after the `is` keyword ([PR](https://github.com/dotnet/roslynator/pull/1800))
 
 ## [4.16.0] - 2026-08-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))
 - [CLI] Fix GitLab output format to use relative paths, forward slashes, and 1-based line numbers ([PR](https://github.com/dotnet/roslynator/pull/1792))
+- Fix code fix for [RCS1172](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1172) to preserve space after the `is` keyword
 
 ## [4.16.0] - 2026-08-08
 

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/UseIsOperatorInsteadOfAsOperatorCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/UseIsOperatorInsteadOfAsOperatorCodeFixProvider.cs
@@ -86,7 +86,9 @@ public sealed class UseIsOperatorInsteadOfAsOperatorCodeFixProvider : BaseCodeFi
                     Token(SyntaxTriviaList.Empty, SyntaxKind.CloseParenToken, SyntaxTriviaList.Empty)));
         }
 
-        newNode = newNode.WithFormatterAnnotation();
+        newNode = newNode
+            .WithTriviaFrom(node)
+            .WithFormatterAnnotation();
 
         return document.ReplaceNodeAsync(node, newNode, cancellationToken);
     }

--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/UseIsOperatorInsteadOfAsOperatorCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/UseIsOperatorInsteadOfAsOperatorCodeFixProvider.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -10,8 +11,8 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslynator.CodeFixes;
-using Roslynator.CSharp.Refactorings;
 using Roslynator.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Roslynator.CSharp.CSharpFactory;
 
 namespace Roslynator.CSharp.CodeFixes;
@@ -57,17 +58,35 @@ public sealed class UseIsOperatorInsteadOfAsOperatorCodeFixProvider : BaseCodeFi
 
         AsExpressionInfo asExpressionInfo = SyntaxInfo.AsExpressionInfo(nullCheck.Expression);
 
+        SyntaxTriviaList isTrailingTrivia = asExpressionInfo.OperatorToken.TrailingTrivia;
+        SyntaxTriviaList typeLeadingTrivia = asExpressionInfo.Type.GetLeadingTrivia();
+
+        if (!isTrailingTrivia.Any(static t => t.IsWhitespaceOrEndOfLineTrivia())
+            && !typeLeadingTrivia.Any(static t => t.IsWhitespaceOrEndOfLineTrivia()))
+        {
+            isTrailingTrivia = isTrailingTrivia.Add(Space);
+        }
+
+        SyntaxToken isKeyword = Token(
+            asExpressionInfo.OperatorToken.LeadingTrivia,
+            SyntaxKind.IsKeyword,
+            isTrailingTrivia);
+
         ExpressionSyntax newNode = IsExpression(
             asExpressionInfo.Expression,
-            SyntaxFactory.Token(asExpressionInfo.OperatorToken.LeadingTrivia, SyntaxKind.IsKeyword, asExpressionInfo.OperatorToken.TrailingTrivia),
-            asExpressionInfo.Type);
+            isKeyword,
+            asExpressionInfo.Type.WithLeadingTrivia(typeLeadingTrivia));
 
         if (nullCheck.IsCheckingNull)
-            newNode = LogicalNotExpression(newNode.WithoutTrivia().Parenthesize()).WithTriviaFrom(newNode);
+        {
+            newNode = LogicalNotExpression(
+                ParenthesizedExpression(
+                    Token(SyntaxTriviaList.Empty, SyntaxKind.OpenParenToken, SyntaxTriviaList.Empty),
+                    newNode,
+                    Token(SyntaxTriviaList.Empty, SyntaxKind.CloseParenToken, SyntaxTriviaList.Empty)));
+        }
 
-        newNode = newNode
-            .Parenthesize()
-            .WithFormatterAnnotation();
+        newNode = newNode.WithFormatterAnnotation();
 
         return document.ReplaceNodeAsync(node, newNode, cancellationToken);
     }

--- a/src/Tests/Analyzers.Tests/RCS1172UseIsOperatorInsteadOfAsOperatorTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1172UseIsOperatorInsteadOfAsOperatorTests.cs
@@ -83,4 +83,30 @@ class MyClass
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseIsOperatorInsteadOfAsOperator)]
+    public async Task Test_EqualsNull_PreservesTrailingTrivia()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class MyClass
+{
+    void M(object item)
+    {
+        if ([|item as MyClass == null|] /*x*/)
+        {
+        }
+    }
+}
+", @"
+class MyClass
+{
+    void M(object item)
+    {
+        if (!(item is MyClass) /*x*/)
+        {
+        }
+    }
+}
+");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1172UseIsOperatorInsteadOfAsOperatorTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1172UseIsOperatorInsteadOfAsOperatorTests.cs
@@ -57,4 +57,30 @@ internal class C
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseIsOperatorInsteadOfAsOperator)]
+    public async Task Test_EqualsNull()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class MyClass
+{
+    void M(object item)
+    {
+        if ([|item as MyClass == null|])
+        {
+        }
+    }
+}
+", @"
+class MyClass
+{
+    void M(object item)
+    {
+        if (!(item is MyClass))
+        {
+        }
+    }
+}
+");
+    }
 }


### PR DESCRIPTION
## Summary

- Fix RCS1172 code fix producing `item isMyClass` / `!(item isMyClass)` by preserving whitespace between `is` and the type
- For `== null` checks, build `!(item is MyClass)` without stripping trivia via `WithoutTrivia().Parenthesize()`
- Add test for `item as MyClass == null`

Fixes #1704

## Test plan

- [x] `dotnet test src/Tests/Analyzers.Tests/Analyzers.Tests.csproj --filter "FullyQualifiedName~RCS1172"`


Made with [Cursor](https://cursor.com)