### PR TITLE
fix(refactorings): offer RR0201 for more interpolated string spans

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix refactoring [RR0201](https://josefpihrt.github.io/docs/roslynator/refactorings/RR0201) to be offered for more cursor positions inside interpolated strings ([#1736](https://github.com/dotnet/roslynator/issues/1736))
+- Fix refactoring [RR0201](https://josefpihrt.github.io/docs/roslynator/refactorings/RR0201) to be offered for more cursor positions inside interpolated strings ([#1736](https://github.com/dotnet/roslynator/issues/1736)) ([PR](https://github.com/dotnet/roslynator/pull/1804))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix refactoring [RR0201](https://josefpihrt.github.io/docs/roslynator/refactorings/RR0201) to be offered for more cursor positions inside interpolated strings ([#1736](https://github.com/dotnet/roslynator/issues/1736))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/src/Analyzers.CodeFixes/docs/NuGetReadme.md
+++ b/src/Analyzers.CodeFixes/docs/NuGetReadme.md
@@ -24,6 +24,7 @@ A collection of 200+ [analyzers](https://josefpihrt.github.io/docs/roslynator/an
 
 ## Related Products
 
+* [Roslynator.Refactorings](https://www.nuget.org/packages/Roslynator.Refactorings) NuGet package (refactorings are not included in this package)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/Refactorings/CSharp/Refactorings/InterpolatedStringRefactoring.cs
+++ b/src/Refactorings/CSharp/Refactorings/InterpolatedStringRefactoring.cs
@@ -61,13 +61,13 @@ internal static class InterpolatedStringRefactoring
         }
 
         if (context.IsRefactoringEnabled(RefactoringDescriptors.ConvertInterpolatedStringToConcatenation)
-            && context.Span.IsEmptyAndContainedInSpanOrBetweenSpans(interpolatedString))
+            && context.Span.IsContainedInSpanOrBetweenSpans(interpolatedString))
         {
             ConvertInterpolatedStringToConcatenationRefactoring.ComputeRefactoring(context, interpolatedString);
         }
 
         if (context.IsRefactoringEnabled(RefactoringDescriptors.ConvertInterpolatedStringToStringFormat)
-            && context.Span.IsEmptyAndContainedInSpanOrBetweenSpans(interpolatedString))
+            && context.Span.IsContainedInSpanOrBetweenSpans(interpolatedString))
         {
             ConvertInterpolatedStringToStringFormatRefactoring.ComputeRefactoring(context, interpolatedString);
         }

--- a/src/Refactorings/CSharp/Refactorings/RefactoringContext.cs
+++ b/src/Refactorings/CSharp/Refactorings/RefactoringContext.cs
@@ -187,6 +187,9 @@ internal class RefactoringContext
         if (CodeAnalysisConfig.Instance.Refactorings.TryGetValue(refactoring.OptionKey, out enabled))
             return enabled;
 
+        if (CodeAnalysisConfig.Instance.Refactorings.TryGetValue(refactoring.Id, out enabled))
+            return enabled;
+
         return CodeAnalysisConfig.Instance.RefactoringsEnabled ?? true;
     }
 

--- a/src/Tests/Refactorings.Tests/RR0201ConvertInterpolatedStringToStringFormatTests.cs
+++ b/src/Tests/Refactorings.Tests/RR0201ConvertInterpolatedStringToStringFormatTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Roslynator.Testing.CSharp;
+using Xunit;
+
+namespace Roslynator.CSharp.Refactorings.Tests;
+
+public class RR0201ConvertInterpolatedStringToStringFormatTests : AbstractCSharpRefactoringVerifier
+{
+    public override string RefactoringId { get; } = RefactoringIdentifiers.ConvertInterpolatedStringToStringFormat;
+
+    [Fact, Trait(Traits.Refactoring, RefactoringIdentifiers.ConvertInterpolatedStringToStringFormat)]
+    public async Task Test()
+    {
+        await VerifyRefactoringAsync("""
+class C
+{
+    void M(string name, double value)
+    {
+        var s = [||]$"name: {name,0:f}, value: {value}";
+    }
+}
+""", """
+class C
+{
+    void M(string name, double value)
+    {
+        var s = string.Format("name: {0,0:f}, value: {1}", name, value);
+    }
+}
+""", equivalenceKey: EquivalenceKey.Create(RefactoringId));
+    }
+
+    [Fact, Trait(Traits.Refactoring, RefactoringIdentifiers.ConvertInterpolatedStringToStringFormat)]
+    public async Task Test_InsideInterpolation()
+    {
+        await VerifyRefactoringAsync("""
+class C
+{
+    void M(string name)
+    {
+        var s = $"prefix {[||]name} suffix";
+    }
+}
+""", """
+class C
+{
+    void M(string name)
+    {
+        var s = string.Format("prefix {0} suffix", name);
+    }
+}
+""", equivalenceKey: EquivalenceKey.Create(RefactoringId));
+    }
+
+    [Fact, Trait(Traits.Refactoring, RefactoringIdentifiers.ConvertInterpolatedStringToStringFormat)]
+    public async Task Test_OnLiteralText()
+    {
+        await VerifyRefactoringAsync("""
+class C
+{
+    void M(string name)
+    {
+        var s = $"prefix[||] {name} suffix";
+    }
+}
+""", """
+class C
+{
+    void M(string name)
+    {
+        var s = string.Format("prefix {0} suffix", name);
+    }
+}
+""", equivalenceKey: EquivalenceKey.Create(RefactoringId));
+    }
+
+    [Fact, Trait(Traits.Refactoring, RefactoringIdentifiers.ConvertInterpolatedStringToStringFormat)]
+    public async Task Test_VerbatimInterpolatedString()
+    {
+        await VerifyRefactoringAsync("""
+class C
+{
+    void M(string name)
+    {
+        var s = [||]$@"path\{name}\file";
+    }
+}
+""", """
+class C
+{
+    void M(string name)
+    {
+        var s = string.Format(@"path\{0}\file", name);
+    }
+}
+""", equivalenceKey: EquivalenceKey.Create(RefactoringId));
+    }
+}


### PR DESCRIPTION
## Summary

- Relax span checks for RR0201 (convert interpolated string to `string.Format`) and convert-to-concatenation so refactorings are offered when the caret is between interpolated string tokens, not only strictly inside the node span.
- Fix `IsRefactoringEnabled` to also resolve refactoring settings by RR id (e.g. `RR0201`), matching how Visual Studio options store them.
- Clarify in the `Roslynator.Analyzers` NuGet readme that refactorings require the separate `Roslynator.Refactorings` package (addresses the NuGet vs VS extension confusion in #1736).
- Add tests for RR0201 covering basic usage, cursor inside interpolation, on literal text, and verbatim interpolated strings.

Fixes #1736

## Test plan

- [x] `dotnet test src/Tests/Refactorings.Tests --filter FullyQualifiedName~RR0201`

Made with [Cursor](https://cursor.com)