### PR TITLE
test(analyzers): add RCS0034 regression test for #1724

### DIFF
--- a/src/Tests/Formatting.Analyzers.Tests/RCS0034PutTypeParameterConstraintOnItsOwnLineTests.cs
+++ b/src/Tests/Formatting.Analyzers.Tests/RCS0034PutTypeParameterConstraintOnItsOwnLineTests.cs
@@ -182,6 +182,20 @@ internal sealed class Example<TEntry, TValue>(TEntry entry)
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.PutTypeParameterConstraintOnItsOwnLine)]
+    public async Task TestNoDiagnostic_PrimaryConstructor_MixedConstraints()
+    {
+        await VerifyNoDiagnosticAsync(@"
+public class MixedConstraintService<TKey, TValue>(TKey key, TValue value)
+    where TKey : notnull
+    where TValue : new()
+{
+    public TKey Key { get; } = key;
+    public TValue Value { get; } = value;
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.PutTypeParameterConstraintOnItsOwnLine)]
     public async Task TestNoDiagnostic_BaseType()
     {
         await VerifyNoDiagnosticAsync(@"


### PR DESCRIPTION
## Summary

#1724 is already fixed on `main` by [#1791](https://github.com/dotnet/roslynator/pull/1791) (RCS0034 anchors constraint trivia on the primary constructor closing `)` instead of the type parameter list).

This PR adds a regression test using the exact scenario from #1724 (`notnull` + `new()` constraints with two primary constructor parameters).

Closes #1724

## Test plan

- [x] `dotnet test src/Tests/Formatting.Analyzers.Tests --filter FullyQualifiedName~RCS0034`

Made with [Cursor](https://cursor.com)