### PR TITLE
fix(analyzers): skip RCS1231 for ref struct parameters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix analyzer [RCS1231](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1231) to not suggest `in` for `ref struct` parameters ([#1725](https://github.com/dotnet/roslynator/issues/1725))
+- Fix analyzer [RCS1231](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1231) to not suggest `in` for `ref struct` parameters ([#1725](https://github.com/dotnet/roslynator/issues/1725)) ([PR](https://github.com/dotnet/roslynator/pull/1807))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix analyzer [RCS1231](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1231) to not suggest `in` for `ref struct` parameters ([#1725](https://github.com/dotnet/roslynator/issues/1725))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/src/Analyzers/CSharp/Analysis/RefReadOnlyParameterAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/RefReadOnlyParameterAnalyzer.cs
@@ -142,6 +142,9 @@ public sealed class RefReadOnlyParameterAnalyzer : BaseDiagnosticAnalyzer
                 continue;
             }
 
+            if (type.IsRefLikeType)
+                continue;
+
             if (parameter.RefKind != RefKind.None)
                 continue;
 

--- a/src/Tests/Analyzers.Tests/RCS1231MakeParameterRefReadOnlyTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1231MakeParameterRefReadOnlyTests.cs
@@ -196,6 +196,22 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MakeParameterRefReadOnly)]
+    public async Task TestNoDiagnostic_RefStruct_Returned()
+    {
+        await VerifyNoDiagnosticAsync(@"
+public readonly ref struct RefStruct;
+
+public static class Methods
+{
+    public static RefStruct DoSomething(RefStruct @struct)
+    {
+        return @struct;
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MakeParameterRefReadOnly)]
     public async Task TestNoDiagnostic_ExpressionTree()
     {
         await VerifyNoDiagnosticAsync(@"


### PR DESCRIPTION
## Summary

- Skip RCS1231 (`Make parameter ref read-only`) for `ref struct` parameters; suggesting `in` can break returning the parameter by value.

Fixes #1725

## Test plan

- [x] `dotnet test src/Tests/Analyzers.Tests --filter FullyQualifiedName~RCS1231`

Made with [Cursor](https://cursor.com)