### PR TITLE
fix(analyzers): align RCS1260 single-line check with initializer braces

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix analyzer [RCS1260](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1260) false positive for `omit_when_single_line` on multi-line object/collection initializers ([#1439](https://github.com/dotnet/roslynator/issues/1439))
+- Fix analyzer [RCS1260](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1260) false positive for `omit_when_single_line` on multi-line object/collection initializers ([#1439](https://github.com/dotnet/roslynator/issues/1439)) ([PR](https://github.com/dotnet/roslynator/pull/1808))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix analyzer [RCS1260](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1260) false positive for `omit_when_single_line` on multi-line object/collection initializers ([#1439](https://github.com/dotnet/roslynator/issues/1439))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/src/Analyzers/CSharp/Analysis/AddOrRemoveTrailingCommaAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/AddOrRemoveTrailingCommaAnalyzer.cs
@@ -61,6 +61,7 @@ public sealed class AddOrRemoveTrailingCommaAnalyzer : BaseDiagnosticAnalyzer
 
         int count = expressions.Count;
         int separatorCount = expressions.SeparatorCount;
+        TextSpan bracesSpan = TextSpan.FromBounds(initializer.OpenBraceToken.SpanStart, initializer.CloseBraceToken.Span.End);
 
         if (count == separatorCount)
         {
@@ -69,7 +70,7 @@ public sealed class AddOrRemoveTrailingCommaAnalyzer : BaseDiagnosticAnalyzer
                 ReportRemove(context, expressions.GetSeparator(count - 1));
             }
             else if (style == TrailingCommaStyle.OmitWhenSingleLine
-                && initializer.IsSingleLine(cancellationToken: context.CancellationToken))
+                && bracesSpan.IsSingleLine(initializer.SyntaxTree, cancellationToken: context.CancellationToken))
             {
                 ReportRemove(context, expressions.GetSeparator(count - 1));
             }
@@ -81,7 +82,7 @@ public sealed class AddOrRemoveTrailingCommaAnalyzer : BaseDiagnosticAnalyzer
                 ReportAdd(context, expressions.Last());
             }
             else if (style == TrailingCommaStyle.OmitWhenSingleLine
-                && !initializer.IsSingleLine(cancellationToken: context.CancellationToken))
+                && !bracesSpan.IsSingleLine(initializer.SyntaxTree, cancellationToken: context.CancellationToken))
             {
                 ReportAdd(context, expressions.Last());
             }

--- a/src/Tests/Analyzers.Tests/RCS1260AddOrRemoveTrailingCommaTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1260AddOrRemoveTrailingCommaTests.cs
@@ -569,4 +569,45 @@ class C
      }
      """, options: Options.AddConfigOption(ConfigOptionKeys.TrailingCommaStyle, ConfigOptionValues.TrailingCommaStyle_Omit));
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AddOrRemoveTrailingComma)]
+    public async Task TestNoDiagnostic_ObjectInitializer_OmitWhenSingleLine_SingleProperty()
+    {
+        await VerifyNoDiagnosticAsync("""
+class Object
+{
+    public string Property1 { get; set; }
+}
+
+class C
+{
+    void M()
+    {
+        var value = new Object
+        {
+            Property1 = "Value",
+        };
+    }
+}
+""", options: Options.AddConfigOption(ConfigOptionKeys.TrailingCommaStyle, ConfigOptionValues.TrailingCommaStyle_OmitWhenSingleLine));
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AddOrRemoveTrailingComma)]
+    public async Task TestNoDiagnostic_CollectionInitializer_OmitWhenSingleLine_SingleElement()
+    {
+        await VerifyNoDiagnosticAsync("""
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        var dict = new Dictionary<int, int>
+        {
+            { 1, 2 },
+        };
+    }
+}
+""", options: Options.AddConfigOption(ConfigOptionKeys.TrailingCommaStyle, ConfigOptionValues.TrailingCommaStyle_OmitWhenSingleLine));
+    }
 }


### PR DESCRIPTION
## Summary

- Use brace span (`OpenBraceToken` → `CloseBraceToken`) for `omit_when_single_line` on initializer expressions, matching enum/anonymous object/switch/pattern checks in the same analyzer.
- The original false positive (#1439) was addressed in #1685 by switching from `expressions.IsSingleLine()` to `initializer.IsSingleLine()`; this aligns the initializer path with the explicit brace-span approach used elsewhere.
- Add regression tests for multi-line object and collection initializers with a single element and trailing comma.

Fixes #1439

## Test plan

- [x] `dotnet test src/Tests/Analyzers.Tests --filter FullyQualifiedName~RCS1260`

Made with [Cursor](https://cursor.com)