### PR TITLE
fix(analyzers): skip RCS1102 for nested classes with instance members

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix analyzer [RCS1102](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1102) false positive when a class with nested instance members is used as a type argument ([#1474](https://github.com/dotnet/roslynator/issues/1474))
+- Fix analyzer [RCS1102](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1102) false positive when a class with nested instance members is used as a type argument ([#1474](https://github.com/dotnet/roslynator/issues/1474)) ([PR](https://github.com/dotnet/roslynator/pull/1809))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix analyzer [RCS1102](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1102) false positive when a class with nested instance members is used as a type argument ([#1474](https://github.com/dotnet/roslynator/issues/1474))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/src/Analyzers/CSharp/Analysis/MakeClassStaticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/MakeClassStaticAnalyzer.cs
@@ -129,6 +129,12 @@ public sealed class MakeClassStaticAnalyzer : BaseDiagnosticAnalyzer
                             if (memberSymbol.DeclaredAccessibility.ContainsProtected())
                                 return false;
 
+                            if (namedTypeSymbol.TypeKind == TypeKind.Class
+                                && !CanBeNestedInStaticClass(namedTypeSymbol))
+                            {
+                                return false;
+                            }
+
                             break;
                         }
                         default:
@@ -169,6 +175,49 @@ public sealed class MakeClassStaticAnalyzer : BaseDiagnosticAnalyzer
         }
 
         return !areAllImplicitlyDeclared;
+    }
+
+    private static bool CanBeNestedInStaticClass(INamedTypeSymbol nestedClass)
+    {
+        foreach (ISymbol memberSymbol in nestedClass.GetMembers())
+        {
+            if (memberSymbol.IsImplicitlyDeclared)
+                continue;
+
+            if (memberSymbol.DeclaredAccessibility.ContainsProtected())
+                return false;
+
+            switch (memberSymbol.Kind)
+            {
+                case SymbolKind.NamedType:
+                {
+                    var namedTypeSymbol = (INamedTypeSymbol)memberSymbol;
+
+                    if (namedTypeSymbol.TypeKind == TypeKind.Class
+                        && !CanBeNestedInStaticClass(namedTypeSymbol))
+                    {
+                        return false;
+                    }
+
+                    break;
+                }
+                default:
+                {
+                    if (!memberSymbol.IsStatic)
+                        return false;
+
+                    if (memberSymbol.Kind == SymbolKind.Method
+                        && ((IMethodSymbol)memberSymbol).MethodKind.Is(MethodKind.UserDefinedOperator, MethodKind.Conversion))
+                    {
+                        return false;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return true;
     }
 
     private class MakeClassStaticWalker : TypeSyntaxWalker

--- a/src/Tests/Analyzers.Tests/RCS1102MakeClassStaticTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1102MakeClassStaticTests.cs
@@ -176,4 +176,49 @@ public class Class1<T>
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MakeClassStatic)]
+    public async Task TestNoDiagnostic_NestedClassWithInstanceMembers_UsedAsTypeArgument()
+    {
+        await VerifyNoDiagnosticAsync(@"
+public class Common
+{
+}
+
+public class Create<TEntity, TDtoOut> where TEntity : Common
+{
+    public class Command
+    {
+        public int Value { get; set; }
+    }
+
+    public class Handler
+    {
+        public void Handle(Command command)
+        {
+        }
+    }
+}
+
+public class Foo : Common
+{
+}
+
+public class Bar
+{
+}
+
+public static class Registration
+{
+    public static void Register<T>()
+    {
+    }
+
+    public static void M()
+    {
+        Register<Create<Foo, Bar>>();
+    }
+}
+");
+    }
 }


### PR DESCRIPTION
## Summary

- Skip RCS1102 when a nested class contains non-static members, since making the containing class `static` would require nested types to be static as well (breaking patterns like MediatR `Create<T>` with nested `Command`/`Handler` classes).
- Add regression test for generic type-argument usage (`Register<Create<Foo, Bar>>()`).

Fixes #1474

## Test plan

- [x] `dotnet test src/Tests/Analyzers.Tests --filter FullyQualifiedName~RCS1102`

Made with [Cursor](https://cursor.com)