### PR TITLE
chore: add AGENTS.md and Cursor git workflow guardrails

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -14,7 +14,7 @@ alwaysApply: true
 - Avoid `--force` / `--force-with-lease` on shared branches unless the user explicitly requests it.
 - Do not create commits unless the user asks.
 - Do not skip git hooks (`--no-verify`) unless the user asks.
-- Do not merge your own PR unless the user explicitly asks.
+- Do not merge a PR unless the user explicitly asks.
 - When a PR resolves a GitHub issue, include `Fixes #NNNN` (or `Closes #NNNN`) on its own line in the PR body. A markdown link alone does not create a GitHub issue reference or auto-close the issue.
 
 ## This repository

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -15,6 +15,7 @@ alwaysApply: true
 - Do not create commits unless the user asks.
 - Do not skip git hooks (`--no-verify`) unless the user asks.
 - Do not merge your own PR unless the user explicitly asks.
+- When a PR resolves a GitHub issue, include `Fixes #NNNN` (or `Closes #NNNN`) on its own line in the PR body. A markdown link alone does not create a GitHub issue reference or auto-close the issue.
 
 ## This repository
 

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -3,24 +3,4 @@ description: Git and PR guardrails for AI agents
 alwaysApply: true
 ---
 
-# Agent instructions
-
-## Git workflow
-
-- Never push or commit directly to `main` (or `master`).
-- Create a feature branch, commit there, and open a PR.
-- Do not push to remote unless the user asks.
-- Do not force-push to `main` or rewrite published history unless the user explicitly requests it.
-- Avoid `--force` / `--force-with-lease` on shared branches unless the user explicitly requests it.
-- Do not create commits unless the user asks.
-- Do not skip git hooks (`--no-verify`) unless the user asks.
-- Do not merge a PR unless the user explicitly asks.
-- When a PR resolves a GitHub issue, include `Fixes #NNNN` (or `Closes #NNNN`) on its own line in the PR body. A markdown link alone does not create a GitHub issue reference or auto-close the issue.
-
-## This repository
-
-- Follow [CONTRIBUTING.md](CONTRIBUTING.md).
-- Use [.claude/skills/](.claude/skills/) for analyzer, refactoring, compiler-fix, bug-fix, deprecation, and release workflows.
-- Do not implement a new analyzer, refactoring, or compiler fix without an approved GitHub issue.
-
-See also [AGENTS.md](../../AGENTS.md) at the repository root (source of truth).
+Follow [AGENTS.md](../../AGENTS.md) at the repository root (source of truth).

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,0 +1,25 @@
+---
+description: Git and PR guardrails for AI agents
+alwaysApply: true
+---
+
+# Agent instructions
+
+## Git workflow
+
+- Never push or commit directly to `main` (or `master`).
+- Create a feature branch, commit there, and open a PR.
+- Do not push to remote unless the user asks.
+- Do not force-push to `main` or rewrite published history unless the user explicitly requests it.
+- Avoid `--force` / `--force-with-lease` on shared branches unless the user explicitly requests it.
+- Do not create commits unless the user asks.
+- Do not skip git hooks (`--no-verify`) unless the user asks.
+- Do not merge your own PR unless the user explicitly asks.
+
+## This repository
+
+- Follow [CONTRIBUTING.md](CONTRIBUTING.md).
+- Use [.claude/skills/](.claude/skills/) for analyzer, refactoring, compiler-fix, bug-fix, deprecation, and release workflows.
+- Do not implement a new analyzer, refactoring, or compiler fix without an approved GitHub issue.
+
+See also [AGENTS.md](../../AGENTS.md) at the repository root (source of truth).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - Avoid `--force` / `--force-with-lease` on shared branches unless the user explicitly requests it.
 - Do not create commits unless the user asks.
 - Do not skip git hooks (`--no-verify`) unless the user asks.
-- Do not merge your own PR unless the user explicitly asks.
+- Do not merge a PR unless the user explicitly asks.
 - When a PR resolves a GitHub issue, include `Fixes #NNNN` (or `Closes #NNNN`) on its own line in the PR body. A markdown link alone does not create a GitHub issue reference or auto-close the issue.
 
 ## This repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent instructions
+
+## Git workflow
+
+- Never push or commit directly to `main` (or `master`).
+- Create a feature branch, commit there, and open a PR.
+- Do not push to remote unless the user asks.
+- Do not force-push to `main` or rewrite published history unless the user explicitly requests it.
+- Avoid `--force` / `--force-with-lease` on shared branches unless the user explicitly requests it.
+- Do not create commits unless the user asks.
+- Do not skip git hooks (`--no-verify`) unless the user asks.
+- Do not merge your own PR unless the user explicitly asks.
+
+## This repository
+
+- Follow [CONTRIBUTING.md](CONTRIBUTING.md).
+- Use [.claude/skills/](.claude/skills/) for analyzer, refactoring, compiler-fix, bug-fix, deprecation, and release workflows.
+- Do not implement a new analyzer, refactoring, or compiler fix without an approved GitHub issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,7 @@
 - Never push or commit directly to `main` (or `master`).
 - Create a feature branch, commit there, and open a PR.
 - Do not push to remote unless the user asks.
-- Do not force-push to `main` or rewrite published history unless the user explicitly requests it.
-- Avoid `--force` / `--force-with-lease` on shared branches unless the user explicitly requests it.
+- Do not force-push to `main`, rewrite published history, or use `--force` / `--force-with-lease` on shared branches unless the user explicitly requests it.
 - Do not create commits unless the user asks.
 - Do not skip git hooks (`--no-verify`) unless the user asks.
 - Do not merge a PR unless the user explicitly asks.
@@ -15,5 +14,4 @@
 ## This repository
 
 - Follow [CONTRIBUTING.md](CONTRIBUTING.md).
-- Use [.claude/skills/](.claude/skills/) for analyzer, refactoring, compiler-fix, bug-fix, deprecation, and release workflows.
-- Do not implement a new analyzer, refactoring, or compiler fix without an approved GitHub issue.
+- New `RCS` / `RR` / `RCF` work requires an approved GitHub issue (see CONTRIBUTING.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Do not create commits unless the user asks.
 - Do not skip git hooks (`--no-verify`) unless the user asks.
 - Do not merge your own PR unless the user explicitly asks.
+- When a PR resolves a GitHub issue, include `Fixes #NNNN` (or `Closes #NNNN`) on its own line in the PR body. A markdown link alone does not create a GitHub issue reference or auto-close the issue.
 
 ## This repository
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Guidelines for contributing to the Roslynator repo.
 
 ## Agent Skills
 
+Global agent rules: [AGENTS.md](AGENTS.md).
+
 **Agent skills** in [.claude/skills/](.claude/skills/) are step-by-step workflows for AI coding agents (Cursor, Claude Code). They also work as readable contributor guides — open any `SKILL.md` in that folder.
 
 | Skill | Use when |


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with git/PR guardrails (never push or commit on `main`, ask before push/commit, no force-push/hooks skip unless asked).
- Mirror the same rules in `.cursor/rules/git-workflow.mdc` (`alwaysApply: true`).
- Link `AGENTS.md` from `CONTRIBUTING.md`.

## Test plan

- [ ] Confirm `AGENTS.md` and `.cursor/rules/git-workflow.mdc` render correctly on GitHub
- [ ] Spot-check CONTRIBUTING Agent Skills section link

Made with [Cursor](https://cursor.com)