### PR TITLE
Fix RCS0036 for blank lines in records

### DIFF
--- a/.claude/skills/fix-analyzer-bug/SKILL.md
+++ b/.claude/skills/fix-analyzer-bug/SKILL.md
@@ -66,7 +66,9 @@ Fixes #NNNN
 
 Use `Fixes #NNNN` or `Closes #NNNN`. A markdown link such as `[#1812](https://github.com/dotnet/roslynator/issues/1812)` does **not** create a GitHub issue reference and will not auto-close the issue.
 
-Place it after the Summary bullets and before the Test plan, for example:
+In `ChangeLog.md`, end the entry with `([PR](https://github.com/dotnet/roslynator/pull/NNNN))` (see [references/changelog-examples.md](references/changelog-examples.md)). Do not use an issue link there.
+
+Place `Fixes #NNNN` after the Summary bullets and before the Test plan, for example:
 
 ```markdown
 ## Summary
@@ -90,4 +92,5 @@ Fixes #1812
 | Full test suite | Filter by rule id is enough |
 | Skip test | CONTRIBUTING.md requires tests for bug fixes |
 | `CHANGELOG.md` | `ChangeLog.md` at repo root |
+| Changelog ends with issue link (`[#NNNN](.../issues/...)`) | End with `([PR](https://github.com/dotnet/roslynator/pull/NNNN))` |
 | Markdown-only issue link in PR body | Use `Fixes #NNNN` so GitHub links and auto-closes the issue |

--- a/.claude/skills/fix-analyzer-bug/SKILL.md
+++ b/.claude/skills/fix-analyzer-bug/SKILL.md
@@ -56,6 +56,28 @@ cd src && dotnet format Roslynator.sln --no-restore --verify-no-changes --severi
 
 Changelog examples: [references/changelog-examples.md](references/changelog-examples.md).
 
+## Pull request
+
+When the fix targets a GitHub issue, the PR body **must** include a closing keyword on its own line (same pattern as recent analyzer fix PRs):
+
+```markdown
+Fixes #NNNN
+```
+
+Use `Fixes #NNNN` or `Closes #NNNN`. A markdown link such as `[#1812](https://github.com/dotnet/roslynator/issues/1812)` does **not** create a GitHub issue reference and will not auto-close the issue.
+
+Place it after the Summary bullets and before the Test plan, for example:
+
+```markdown
+## Summary
+- …
+
+Fixes #1812
+
+## Test plan
+- …
+```
+
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -68,3 +90,4 @@ Changelog examples: [references/changelog-examples.md](references/changelog-exam
 | Full test suite | Filter by rule id is enough |
 | Skip test | CONTRIBUTING.md requires tests for bug fixes |
 | `CHANGELOG.md` | `ChangeLog.md` at repo root |
+| Markdown-only issue link in PR body | Use `Fixes #NNNN` so GitHub links and auto-closes the issue |

--- a/.claude/skills/fix-analyzer-bug/references/changelog-examples.md
+++ b/.claude/skills/fix-analyzer-bug/references/changelog-examples.md
@@ -32,4 +32,5 @@ Prefix with `[CLI]`.
 - Link id to docs URL
 - Plain-language behavior change
 - Backticks for code identifiers
-- PR link when known
+- End with `([PR](https://github.com/dotnet/roslynator/pull/NNNN))` — not an issue link (`[#NNNN](.../issues/...)`)
+- After the PR exists, update the changelog entry if it was drafted without the PR URL

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix analyzer [RCS0036](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0036) to report blank lines between single-line declarations in records ([#1812](https://github.com/dotnet/roslynator/issues/1812))
+- Fix analyzer [RCS0036](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0036) to report blank lines between single-line declarations in records ([PR](https://github.com/dotnet/roslynator/pull/1813))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix analyzer [RCS0036](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0036) to report blank lines between single-line declarations in records ([#1812](https://github.com/dotnet/roslynator/issues/1812))
 - Fix analyzer [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046) to report `async void` methods without `Async` suffix ([PR](https://github.com/dotnet/roslynator/pull/1790))
 - Fix analyzer [RCS1265](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1265) to not report catch clauses with a `when` filter ([PR](https://github.com/dotnet/roslynator/pull/1789))
 - Fix analyzer [RCS0034](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS0034) for types with a primary constructor and multiple constraint clauses ([PR](https://github.com/dotnet/roslynator/pull/1791))

--- a/src/Formatting.Analyzers/CSharp/BlankLineBetweenDeclarationsAnalyzer.cs
+++ b/src/Formatting.Analyzers/CSharp/BlankLineBetweenDeclarationsAnalyzer.cs
@@ -42,6 +42,7 @@ public sealed class BlankLineBetweenDeclarationsAnalyzer : BaseDiagnosticAnalyze
             f => AnalyzeTypeDeclaration(f),
             SyntaxKind.ClassDeclaration,
             SyntaxKind.StructDeclaration,
+            SyntaxKind.RecordDeclaration,
 #if ROSLYN_4_0
             SyntaxKind.RecordStructDeclaration,
 #endif

--- a/src/Tests/Formatting.Analyzers.Tests/RCS0036RemoveBlankLineBetweenSingleLineDeclarationsOfSameKindTests.cs
+++ b/src/Tests/Formatting.Analyzers.Tests/RCS0036RemoveBlankLineBetweenSingleLineDeclarationsOfSameKindTests.cs
@@ -32,6 +32,25 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveBlankLineBetweenSingleLineDeclarationsOfSameKind)]
+    public async Task Test_Properties_Record()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+record C
+{
+    string P1 { get; set; }
+[|
+|]    string P2 { get; set; }
+}
+", @"
+record C
+{
+    string P1 { get; set; }
+    string P2 { get; set; }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveBlankLineBetweenSingleLineDeclarationsOfSameKind)]
     public async Task Test_Events()
     {
         await VerifyDiagnosticAndFixAsync(@"


### PR DESCRIPTION
## Summary
- RCS0036 now visits `record` declarations, so blank lines between consecutive single-line properties (and other same-kind members) are reported the same way as in classes.
- The shared `BlankLineBetweenDeclarationsAnalyzer` registration also covers RCS0009, RCS0010, RCS0012, and RCS0013 inside records.
- Adds a regression test matching the issue reproduction.

Fixes #1812

## Test plan
- [x] `dotnet test Tests/Formatting.Analyzers.Tests --filter "FullyQualifiedName~RCS0036"` (8 passed)
- [ ] Confirm the issue reproduction (`record` with two single-line properties separated by a blank line) reports RCS0036 and the code fix removes the blank line