### PR TITLE
docs(skills): gate release-roslynator on four confirmation steps

### DIFF
--- a/.claude/skills/release-roslynator/SKILL.md
+++ b/.claude/skills/release-roslynator/SKILL.md
@@ -30,7 +30,7 @@ Before each step below: present what you will do, then use interactive confirmat
 | Step | Gate | Action |
 |------|------|--------|
 | 1 | Confirm before push/PR | Changelog PR (`ChangeLog.md` + VS Code `CHANGELOG.md`) |
-| 2 | Confirm before merge | Merge PR; pull `main` |
+| 2 | Confirm before merge | Squash-merge PR; pull `main` |
 | 3 | Confirm before create | GitHub release → creates `vX.Y.Z`; title same as tag (`vX.Y.Z`) |
 | 4 | Opt-in only | Optional `cli-v*` tag on a real commit; push |
 
@@ -53,7 +53,13 @@ Do **not** run `generate_all.ps1` as part of this PR unless the user asks.
 
 **STOP until user confirms Step 2.**
 
-Merge the bump PR (after CI is acceptable to the user). Pull latest `main`. Note the merge commit SHA.
+Squash-merge the bump PR (after CI is acceptable to the user):
+
+```bash
+gh pr merge <PR_NUMBER> --squash
+```
+
+Pull latest `main`. Note the squash commit SHA on `main`.
 
 **STOP.** Wait for Step 3 confirmation.
 
@@ -66,7 +72,7 @@ Create the analyzer/extension release (this creates/pushes tag `vX.Y.Z` and trig
 - Tag: `vX.Y.Z`
 - Title: `vX.Y.Z` (same as tag, **with** `v` prefix)
 - Notes: body of `## [X.Y.Z]` from root `ChangeLog.md` (sections under that header, not the heading line alone)
-- Target: merge commit on `main` (or `main` after pull)
+- Target: squash commit on `main` (or `main` after pull)
 
 Example:
 

--- a/.claude/skills/release-roslynator/SKILL.md
+++ b/.claude/skills/release-roslynator/SKILL.md
@@ -41,8 +41,8 @@ CI / GitVersion details: [references/release-and-ci.md](references/release-and-c
 **STOP until user confirms Step 1.**
 
 1. Branch from latest `main` (e.g. `release/X.Y.Z`).
-2. Root [`ChangeLog.md`](../../ChangeLog.md): under `## [Unreleased]`, insert `## [X.Y.Z] - YYYY-MM-DD` so prior Unreleased bullets become that version’s section (same pattern as bump PR #1785). Leave `[Unreleased]` empty above it.
-3. [`src/VisualStudioCode/package/CHANGELOG.md`](../../src/VisualStudioCode/package/CHANGELOG.md): copy that new version section (header + body) under `[Unreleased]`.
+2. Root [`ChangeLog.md`](../../../ChangeLog.md): under `## [Unreleased]`, insert `## [X.Y.Z] - YYYY-MM-DD` so prior Unreleased bullets become that version’s section (same pattern as bump PR #1785). Leave `[Unreleased]` empty above it.
+3. [`src/VisualStudioCode/package/CHANGELOG.md`](../../../src/VisualStudioCode/package/CHANGELOG.md): copy that new version section (header + body) under `[Unreleased]`.
 4. Commit, push, open PR — title `Bump version to X.Y.Z`.
 
 Do **not** run `generate_all.ps1` as part of this PR unless the user asks.

--- a/.claude/skills/release-roslynator/SKILL.md
+++ b/.claude/skills/release-roslynator/SKILL.md
@@ -1,42 +1,104 @@
 ---
 name: release-roslynator
-description: Use when preparing a roslynator release, creating v* or cli-v* version tags, rolling ChangeLog.md [Unreleased], running generate_all.ps1 (not just generate_code), or bumping RoslynatorRef in josefpihrt.github.io CI.
+description: Use when shipping a roslynator release, rolling ChangeLog.md [Unreleased], updating the VS Code extension changelog, creating a GitHub v* release, or optionally tagging cli-v*.
 ---
 
 # Release Roslynator
 
 ## Overview
 
-GitVersion derives versions from tags. Separate streams: `v*` (analyzers/extensions) and `cli-v*` (CLI). After tag, bump docs site CI pins.
+Four hard-gated steps: changelog PR → merge → GitHub release (`v*`) → optional CLI tag (`cli-v*`). Versions come from the user. GitVersion derives package versions from tags — do not hardcode in props.
 
-## When to Use
+**Violating the letter of the gates is violating the spirit of the gates.** Do not batch steps or confirm once for the whole release.
 
-- Shipping a new analyzer/extension version
-- CLI-only release (`cli-v*`)
-- Rolling `## [Unreleased]` into a versioned changelog section
-- Post-release docs alignment (`RoslynatorRef` / `RoslynatorCliRef`)
+## Prerequisites
 
-**Not for:** day-to-day contributor workflows; docs publication details → `update-roslynator-docs` in docs repo.
+- **Analyzer/extension version** (e.g. `4.17.0`) — required. If missing: **STOP. Do NOT proceed.** Ask the user.
+- **CLI version** (e.g. `0.15.0` / `cli-v0.15.0`) — only needed if Step 4 is confirmed.
+- **Today’s date** for changelog headers (`YYYY-MM-DD`).
+
+**Not for:** day-to-day contributor work.
+
+## Hard gates
+
+Before each step below: present what you will do, then use interactive confirmation (`AskQuestion` if available; otherwise ask and wait). Do **not** use markdown checkboxes.
+
+**STOP. Do NOT proceed** to the next step until the user explicitly confirms the current step. Providing a CLI version does **not** skip Step 4 confirmation.
 
 ## Quick Reference
 
-| Step | Action |
-|------|--------|
-| Changelog | Roll `ChangeLog.md` `[Unreleased]` → `[x.y.z] - date` |
-| Generate | `cd tools && pwsh ./generate_all.ps1` |
-| Verify | See [references/release-and-ci.md](references/release-and-ci.md) CI verify block |
-| Tag | `v4.x.y` or `cli-v0.x.y` |
-| Docs pins | `RoslynatorRef` / `RoslynatorCliRef` in docs site workflow |
+| Step | Gate | Action |
+|------|------|--------|
+| 1 | Confirm before push/PR | Changelog PR (`ChangeLog.md` + VS Code `CHANGELOG.md`) |
+| 2 | Confirm before merge | Merge PR; pull `main` |
+| 3 | Confirm before create | GitHub release → creates `vX.Y.Z`; title same as tag (`vX.Y.Z`) |
+| 4 | Opt-in only | Optional `cli-v*` tag on a real commit; push |
 
-Details: [references/release-and-ci.md](references/release-and-ci.md).
+CI / GitVersion details: [references/release-and-ci.md](references/release-and-ci.md).
+
+## Step 1 — Changelog PR
+
+**STOP until user confirms Step 1.**
+
+1. Branch from latest `main` (e.g. `release/X.Y.Z`).
+2. Root [`ChangeLog.md`](../../ChangeLog.md): under `## [Unreleased]`, insert `## [X.Y.Z] - YYYY-MM-DD` so prior Unreleased bullets become that version’s section (same pattern as bump PR #1785). Leave `[Unreleased]` empty above it.
+3. [`src/VisualStudioCode/package/CHANGELOG.md`](../../src/VisualStudioCode/package/CHANGELOG.md): copy that new version section (header + body) under `[Unreleased]`.
+4. Commit, push, open PR — title `Bump version to X.Y.Z`.
+
+Do **not** run `generate_all.ps1` as part of this PR unless the user asks.
+
+**STOP.** Wait for Step 2 confirmation.
+
+## Step 2 — Merge
+
+**STOP until user confirms Step 2.**
+
+Merge the bump PR (after CI is acceptable to the user). Pull latest `main`. Note the merge commit SHA.
+
+**STOP.** Wait for Step 3 confirmation.
+
+## Step 3 — GitHub release
+
+**STOP until user confirms Step 3.**
+
+Create the analyzer/extension release (this creates/pushes tag `vX.Y.Z` and triggers publish CI):
+
+- Tag: `vX.Y.Z`
+- Title: `vX.Y.Z` (same as tag, **with** `v` prefix)
+- Notes: body of `## [X.Y.Z]` from root `ChangeLog.md` (sections under that header, not the heading line alone)
+- Target: merge commit on `main` (or `main` after pull)
+
+Example:
+
+```bash
+gh release create "vX.Y.Z" --title "vX.Y.Z" --notes "..." --target "<sha-or-main>"
+```
+
+**STOP.** Wait for Step 4 confirmation (or user declines CLI tagging).
+
+## Step 4 — Optional CLI tag
+
+**STOP until user opts in.** If they decline, the release workflow ends here.
+
+If yes (CLI version required — ask if missing):
+
+1. `git checkout main && git pull origin main`
+2. Tag `cli-vA.B.C` on a real commit (same commit as `vX.Y.Z` unless the user specifies otherwise)
+3. `git push origin cli-vA.B.C`
+4. Verify both `v*` and `cli-v*` resolve to commits (`git rev-parse`, `git ls-remote`)
+
+Do not amend published tags.
 
 ## Common Mistakes
 
 | Mistake | Fix |
-|---------|-----|
-| Only `generate_code.ps1` at release | Use `generate_all.ps1` — includes metadata, CLI docs, API ref |
-| Hardcode version in props | GitVersion + tag drives CI version |
-| Same tag for CLI and analyzers | Separate `v*` and `cli-v*` streams |
-| Skip docs pin bump in docs site repo | Update `RoslynatorRef` / `RoslynatorCliRef` in workflow |
-| `CHANGELOG.md` | `ChangeLog.md` at repo root |
-| Amend published tag | Create new tag instead |
+|---------|------|
+| Title `4.17.0` without `v` | Title matches tag: `v4.17.0` |
+| Tag CLI because version was in the prompt | Step 4 is opt-in; still ask |
+| Merge + release + CLI in one go | Four separate STOPs |
+| Soft “ask later” while editing/pushing | Confirm **before** push/PR, merge, `gh release create`, CLI tag push |
+| `generate_all.ps1` in bump PR | Out of scope unless the user asks |
+| Root `CHANGELOG.md` | Root file is `ChangeLog.md` |
+| Same tag for CLI and analyzers | `v*` vs `cli-v*` |
+| Amend published tag | New tag instead |
+| Hardcode version in props | GitVersion + tags |

--- a/.claude/skills/release-roslynator/references/release-and-ci.md
+++ b/.claude/skills/release-roslynator/references/release-and-ci.md
@@ -1,5 +1,7 @@
 # Release and CI Reference
 
+Supporting facts for `release-roslynator`. The gated release ritual lives in SKILL.md — this file is CI/GitVersion context only.
+
 ## GitVersion (`GitVersion.yml`)
 
 - Version not hardcoded in `Directory.Build.props` — CI sets from SemVer
@@ -8,28 +10,26 @@
 
 ## Tags
 
-| Stream | Pattern | Example |
-|--------|---------|---------|
-| Analyzers, extensions | `v*` | `v4.17.0` |
-| CLI | `cli-v*` | `cli-v0.14.0` |
+| Stream | Pattern | Example | How it is created |
+|--------|---------|---------|-------------------|
+| Analyzers, extensions | `v*` | `v4.17.0` | GitHub release (Step 3) |
+| CLI | `cli-v*` | `cli-v0.14.0` | Optional git tag push (Step 4) |
 
 ```bash
-git tag v4.17.0 && git push origin v4.17.0
+# CLI only — analyzer tag normally comes from gh release create
+git tag cli-v0.14.0 <sha> && git push origin cli-v0.14.0
 ```
 
-Do not amend published tags.
+Both tags must point at real commits (often the same bump commit). Do not amend published tags.
 
-## `generate_all.ps1` (from `tools/`)
+## Tag-triggered publish (`.github/workflows/build.yml`)
 
-1. `generate_code.ps1`
-2. `generate_configuration_file.ps1`
-3. `generate_metadata.ps1` → `tools/build/`
-4. `generate_cli_docs.ps1`
-5. `generate_ref_docs.ps1`
+| Tag | Publishes |
+|-----|-----------|
+| `v*` | Analyzer/refactoring/code-fix NuGets, VS Code / Open VSX / VS VSIX |
+| `cli-v*` | CLI NuGet packages |
 
-Most doc output lands in docs site repo, not roslynator.
-
-## CI verify (`.github/workflows/build.yml`)
+## CI verify (optional local check — not a release gate)
 
 ```bash
 cd src && dotnet restore Roslynator.sln
@@ -38,17 +38,16 @@ cd src && dotnet format Roslynator.sln --no-restore --verify-no-changes --severi
 cd src && dotnet test Roslynator.sln --no-build
 ```
 
-## Docs site pins (`josefpihrt.github.io/.github/workflows/build.yml`)
+## `generate_all.ps1` (from `tools/`) — not part of the bump PR
 
-```yaml
-RoslynatorRef: v4.17.0
-RoslynatorCliRef: cli-v0.14.0
-```
+Use only if the user asks or codegen is clearly drifted. Default release bump touches changelogs only.
 
-Controls CI checkout for MetadataGenerator, CLI docs, API ref, `configuration.md`.
+1. `generate_code.ps1`
+2. `generate_configuration_file.ps1`
+3. `generate_metadata.ps1` → `tools/build/`
+4. `generate_cli_docs.ps1`
+5. `generate_ref_docs.ps1`
 
 ## Pack (reference)
 
 Dual Roslyn (`roslyn3.8`, `roslyn4.7`) NuGet packs for analyzer/refactoring/codefix projects. VSIX via msbuild on Windows in `src/VisualStudio`.
-
-Docs site deploys on `v*` tag push to docs repo.


### PR DESCRIPTION
## Summary
- Rewrite `release-roslynator` as a four-step, hard-gated workflow: changelog PR → merge → GitHub release (`v*`, title matches tag) → optional `cli-v*` tag
- Align the CI/GitVersion reference with that ritual; remove docs-repo / `update-roslynator-docs` coupling from this skill

## Test plan
- [ ] Skim SKILL.md against a dry-run “release 4.x.y” prompt and confirm four STOPs, no docs-site steps, CLI tag opt-in only
- [ ] Confirm reference doc no longer points at josefpihrt.github.io pins


Made with [Cursor](https://cursor.com)