### PR TITLE
docs(skills): confirm metadata parameters before implementing

### DIFF
--- a/.claude/skills/add-analyzer/SKILL.md
+++ b/.claude/skills/add-analyzer/SKILL.md
@@ -29,7 +29,7 @@ Use `AskQuestion` when available; otherwise ask conversationally. Batch related 
 
 | Parameter | Required? | Allowed / notes |
 |-----------|-----------|-----------------|
-| `Id` | yes | Next free `RCS0` / `RCS1` / `RCS9` id for the package |
+| `Id` | propose | Compute next free `RCS0` / `RCS1` / `RCS9` id from `Analyzers.xml`; **do not ask** unless the issue conflicts or multiple ids are plausible |
 | `Identifier` | yes | PascalCase; drives generated names |
 | `Title` | yes | Short description |
 | `DefaultSeverity` | yes | `Hidden`, `Info`, `Warning`, or `Error` — **always ask** |
@@ -40,7 +40,7 @@ Use `AskQuestion` when available; otherwise ask conversationally. Batch related 
 | `MinLanguageVersion` | no | Ask only if C# version-gated |
 | Config option | no | See [config-options.md](references/config-options.md) |
 
-Skip asking only when the approved issue or the user's message already states the value explicitly.
+When proposing `Id`, state the chosen value in your plan/summary (e.g. “using next free **RCS9012**”). Skip asking other parameters only when the approved issue or the user's message already states the value explicitly.
 
 ## Quick Reference
 

--- a/.claude/skills/add-analyzer/SKILL.md
+++ b/.claude/skills/add-analyzer/SKILL.md
@@ -21,6 +21,27 @@ Roslynator analyzers are metadata-driven: edit `Analyzers.xml`, codegen, impleme
 
 **Read this skill and `references/implementation.md` before writing tests.** Published [analyzers-testing.md](https://josefpihrt.github.io/docs/roslynator/analyzers-testing) targets NuGet consumers — copying it produces code that does not compile in this repo.
 
+## Confirm metadata parameters (hard gate)
+
+**STOP. Do NOT edit `Analyzers.xml`, run codegen, or implement until the user has confirmed every required parameter below.** Do not invent defaults when the user (or issue) did not state them.
+
+Use `AskQuestion` when available; otherwise ask conversationally. Batch related choices.
+
+| Parameter | Required? | Allowed / notes |
+|-----------|-----------|-----------------|
+| `Id` | yes | Next free `RCS0` / `RCS1` / `RCS9` id for the package |
+| `Identifier` | yes | PascalCase; drives generated names |
+| `Title` | yes | Short description |
+| `DefaultSeverity` | yes | `Hidden`, `Info`, `Warning`, or `Error` — **always ask** |
+| `IsEnabledByDefault` | yes | `true` / `false` — **always ask** (RCS0 often `false`) |
+| `MessageFormat` | if message has `{n}` placeholders | Otherwise omit (same as Title) |
+| Code fix? | yes | Strongly recommended; confirm yes/no |
+| `SupportsFadeOut` / fade-out analyzer | no | Ask only if unused-code style |
+| `MinLanguageVersion` | no | Ask only if C# version-gated |
+| Config option | no | See [config-options.md](references/config-options.md) |
+
+Skip asking only when the approved issue or the user's message already states the value explicitly.
+
 ## Quick Reference
 
 | Step | Location / command |
@@ -35,10 +56,11 @@ Roslynator analyzers are metadata-driven: edit `Analyzers.xml`, codegen, impleme
 
 ## Implementation
 
-1. Add `<Analyzer>` entry; schema in [references/analyzer-schema.md](references/analyzer-schema.md). Use docs-site [analyzer-metadata](https://josefpihrt.github.io/docs/roslynator/analyzer-metadata), not `Template.Analyzers.xml`.
-2. Optional config option before codegen — [references/config-options.md](references/config-options.md).
-3. Codegen from `tools/` (required cwd — see Common Mistakes).
-4. Implement analyzer, code fix (strongly recommended), tests — [references/implementation.md](references/implementation.md).
+1. Confirm metadata parameters (hard gate above).
+2. Add `<Analyzer>` entry; schema in [references/analyzer-schema.md](references/analyzer-schema.md). Use docs-site [analyzer-metadata](https://josefpihrt.github.io/docs/roslynator/analyzer-metadata), not `Template.Analyzers.xml`.
+3. Optional config option before codegen — [references/config-options.md](references/config-options.md).
+4. Codegen from `tools/` (required cwd — see Common Mistakes).
+5. Implement analyzer, code fix (if confirmed), tests — [references/implementation.md](references/implementation.md).
 
 Changelog line:
 
@@ -59,6 +81,7 @@ cd src && dotnet format Roslynator.sln --no-restore --verify-no-changes --severi
 
 | Mistake | Fix |
 |---------|-----|
+| Guess `DefaultSeverity` / `IsEnabledByDefault` | Ask — hard gate above |
 | Follow `analyzers-testing.md` verbatim | In-repo: `AbstractCSharpDiagnosticVerifier` + `Descriptor = DiagnosticRules.X` |
 | `pwsh tools/generate_code.ps1` from repo root | Run `cd tools && pwsh ./generate_code.ps1` — generator uses `../src` relative to cwd |
 | `<Status>` on new analyzer | Use only `IsEnabledByDefault`; lifecycle is `deprecate-analyzer-or-refactoring` |

--- a/.claude/skills/add-analyzer/references/analyzer-schema.md
+++ b/.claude/skills/add-analyzer/references/analyzer-schema.md
@@ -11,7 +11,7 @@ Authoritative reference: https://josefpihrt.github.io/docs/roslynator/analyzer-m
 | `Id` | `RCS` + number. Prefix: `RCS0` formatting, `RCS1` general, `RCS9` code-analysis |
 | `Identifier` | PascalCase name used in generated code (`DiagnosticRules.X`, class names) |
 | `Title` | Short description |
-| `DefaultSeverity` | `Hidden`, `Info`, `Warning`, or `Error` |
+| `DefaultSeverity` | `Hidden`, `Info`, `Warning`, or `Error` — **confirm with user; do not invent** |
 | `Summary` | Longer description (markdown) for generated docs |
 
 ## Common Optional Elements
@@ -19,7 +19,7 @@ Authoritative reference: https://josefpihrt.github.io/docs/roslynator/analyzer-m
 | Element | Description |
 |---------|-------------|
 | `MessageFormat` | Required when the message has parameters; otherwise same as Title |
-| `IsEnabledByDefault` | Default `true`. Set `false` for opt-in analyzers (common for RCS0) |
+| `IsEnabledByDefault` | Default in schema is `true`, but **confirm with user** (do not assume). Set `false` for opt-in analyzers (common for RCS0) |
 | `MinLanguageVersion` | e.g. `9.0` |
 | `SupportsFadeOut` | Fade out reported syntax in the editor |
 | `SupportsFadeOutAnalyzer` | Generates an additional `RCS....FadeOut` analyzer |
@@ -31,6 +31,9 @@ Authoritative reference: https://josefpihrt.github.io/docs/roslynator/analyzer-m
 Do **not** use `<Category>` — it is ignored; all analyzers use `DiagnosticCategories.Roslynator`.
 
 Do **not** set `<Status>` on new analyzers. Lifecycle states are handled by the deprecation skill.
+
+Before writing any of these values into XML, follow the **Confirm metadata parameters** hard gate in `SKILL.md`.
+
 
 ## Example Entry
 

--- a/.claude/skills/add-analyzer/references/analyzer-schema.md
+++ b/.claude/skills/add-analyzer/references/analyzer-schema.md
@@ -34,7 +34,6 @@ Do **not** set `<Status>` on new analyzers. Lifecycle states are handled by the 
 
 Before writing any of these values into XML, follow the **Confirm metadata parameters** hard gate in `SKILL.md`.
 
-
 ## Example Entry
 
 ```xml

--- a/.claude/skills/add-compiler-diagnostic-fix/SKILL.md
+++ b/.claude/skills/add-compiler-diagnostic-fix/SKILL.md
@@ -31,12 +31,12 @@ Use `AskQuestion` when available; otherwise ask conversationally. Batch related 
 |-----------|-----------|--------|
 | Compiler `CS####` id(s) | yes | One RCF may fix multiple CS ids |
 | New `Diagnostics.xml` entry? | if CS not already cataloged | Confirm `Title` / `Message` / `HelpUrl` (usually from Microsoft docs) |
-| `RCF` `Id` | yes | Next free `RCF####` (or extend existing RCF) |
+| `RCF` `Id` | propose | Compute next free `RCF####` from `CodeFixes.xml`, or extend an existing RCF when appropriate; **do not ask** unless ambiguous |
 | `Identifier` | yes | PascalCase for the code fix |
 | `Title` | yes | Code-fix menu / docs title |
 | Code action title | yes | String passed to `CodeAction.Create` (may match or differ from XML Title) |
 
-Skip asking only when the approved issue or the user's message already states the value explicitly.
+When proposing `RCF` `Id`, state the chosen value in your plan/summary (e.g. “using next free **RCF0121**”). Skip asking other parameters only when the approved issue or the user's message already states the value explicitly.
 
 ## Quick Reference
 

--- a/.claude/skills/add-compiler-diagnostic-fix/SKILL.md
+++ b/.claude/skills/add-compiler-diagnostic-fix/SKILL.md
@@ -21,6 +21,23 @@ Compiler fixes use `Diagnostics.xml` + `CodeFixes.xml` → codegen → `Compiler
 
 Read [references/implementation.md](references/implementation.md) before writing tests.
 
+## Confirm metadata parameters (hard gate)
+
+**STOP. Do NOT edit `Diagnostics.xml` / `CodeFixes.xml`, run codegen, or implement until the user has confirmed every required parameter below.** Do not invent titles or identifiers when the user (or issue) did not state them.
+
+Use `AskQuestion` when available; otherwise ask conversationally. Batch related choices.
+
+| Parameter | Required? | Notes |
+|-----------|-----------|--------|
+| Compiler `CS####` id(s) | yes | One RCF may fix multiple CS ids |
+| New `Diagnostics.xml` entry? | if CS not already cataloged | Confirm `Title` / `Message` / `HelpUrl` (usually from Microsoft docs) |
+| `RCF` `Id` | yes | Next free `RCF####` (or extend existing RCF) |
+| `Identifier` | yes | PascalCase for the code fix |
+| `Title` | yes | Code-fix menu / docs title |
+| Code action title | yes | String passed to `CodeAction.Create` (may match or differ from XML Title) |
+
+Skip asking only when the approved issue or the user's message already states the value explicitly.
+
 ## Quick Reference
 
 | Step | Location |
@@ -34,7 +51,8 @@ Read [references/implementation.md](references/implementation.md) before writing
 
 ## Implementation
 
-Full XML, provider, and test patterns: [references/implementation.md](references/implementation.md).
+1. Confirm metadata parameters (hard gate above).
+2. Full XML, provider, and test patterns: [references/implementation.md](references/implementation.md).
 
 Changelog:
 
@@ -55,6 +73,7 @@ cd src && dotnet format Roslynator.sln --no-restore --verify-no-changes --severi
 
 | Mistake | Fix |
 |---------|-----|
+| Guess RCF `Title` / `Identifier` / code-action string | Ask — hard gate above |
 | Follow `compiler-diagnostic-fixes-testing.md` | In-repo: `AbstractCSharpCompilerDiagnosticFixVerifier` |
 | `DiagnosticId = "CS0106"` literal | Use `CompilerDiagnosticIdentifiers.CS####_Identifier` constant |
 | `[|...|]` in compiler fix tests | Compiler diagnostic location is implicit |

--- a/.claude/skills/add-refactoring/SKILL.md
+++ b/.claude/skills/add-refactoring/SKILL.md
@@ -29,14 +29,14 @@ Use `AskQuestion` when available; otherwise ask conversationally. Batch related 
 
 | Parameter | Required? | Notes |
 |-----------|-----------|--------|
-| `Id` | yes | Next free `RR####` |
+| `Id` | propose | Compute next free `RR####` from `Refactorings.xml`; **do not ask** unless the issue conflicts or multiple ids are plausible |
 | `Identifier` | yes | PascalCase; drives generated names |
 | `Title` | yes | Short description (light-bulb text) |
 | `OptionKey` | yes | EditorConfig key segment → `roslynator_refactoring.<key>.enabled` |
 | `Syntaxes` / `Span` | yes for docs | Where it can be invoked (documentation only; registration is in code) |
 | `Summary` / samples | recommended | Confirm if not in the issue |
 
-Skip asking only when the approved issue or the user's message already states the value explicitly.
+When proposing `Id`, state the chosen value in your plan/summary (e.g. “using next free **RR0218**”). Skip asking other parameters only when the approved issue or the user's message already states the value explicitly.
 
 ## Quick Reference
 

--- a/.claude/skills/add-refactoring/SKILL.md
+++ b/.claude/skills/add-refactoring/SKILL.md
@@ -21,6 +21,23 @@ Refactorings are metadata-driven: `Refactorings.xml` → codegen → register in
 
 Read [references/implementation.md](references/implementation.md) before writing tests — public [refactorings-testing.md](https://josefpihrt.github.io/docs/roslynator/refactorings-testing) uses `XunitRefactoringVerifier`, which does not match in-repo tests.
 
+## Confirm metadata parameters (hard gate)
+
+**STOP. Do NOT edit `Refactorings.xml`, run codegen, or implement until the user has confirmed every required parameter below.** Do not invent values the user (or issue) did not state.
+
+Use `AskQuestion` when available; otherwise ask conversationally. Batch related choices.
+
+| Parameter | Required? | Notes |
+|-----------|-----------|--------|
+| `Id` | yes | Next free `RR####` |
+| `Identifier` | yes | PascalCase; drives generated names |
+| `Title` | yes | Short description (light-bulb text) |
+| `OptionKey` | yes | EditorConfig key segment → `roslynator_refactoring.<key>.enabled` |
+| `Syntaxes` / `Span` | yes for docs | Where it can be invoked (documentation only; registration is in code) |
+| `Summary` / samples | recommended | Confirm if not in the issue |
+
+Skip asking only when the approved issue or the user's message already states the value explicitly.
+
 ## Quick Reference
 
 | Step | Location / command |
@@ -34,7 +51,8 @@ Read [references/implementation.md](references/implementation.md) before writing
 
 ## Implementation
 
-Details and examples: [references/implementation.md](references/implementation.md).
+1. Confirm metadata parameters (hard gate above).
+2. Details and examples: [references/implementation.md](references/implementation.md).
 
 Changelog:
 
@@ -55,6 +73,7 @@ cd src && dotnet format Roslynator.sln --no-restore --verify-no-changes --severi
 
 | Mistake | Fix |
 |---------|-----|
+| Guess `Title` / `OptionKey` / `Identifier` | Ask — hard gate above |
 | Follow `refactorings-testing.md` verbatim | In-repo: `AbstractCSharpRefactoringVerifier` + `RefactoringId` override |
 | Missing `<OptionKey>` | Required — EditorConfig id for enable/disable |
 | `CHANGELOG.md` in how-to | File is `ChangeLog.md` at repo root |

--- a/.claude/skills/add-refactoring/references/implementation.md
+++ b/.claude/skills/add-refactoring/references/implementation.md
@@ -60,7 +60,7 @@ References: `RR0011AddArgumentNameTests.cs`, `AddOrRemoveArgumentNameRefactoring
 
 ## Metadata Example
 
-Confirm `Id`, `Identifier`, `Title`, and `OptionKey` with the user before writing XML (see hard gate in `SKILL.md`).
+Confirm `Identifier`, `Title`, and `OptionKey` with the user before writing XML (see hard gate in `SKILL.md`). Propose the next free `Id` from `Refactorings.xml` unless ambiguous.
 
 ```xml
 <Refactoring Id="RR0011" Identifier="AddArgumentName" Title="Add argument name">

--- a/.claude/skills/add-refactoring/references/implementation.md
+++ b/.claude/skills/add-refactoring/references/implementation.md
@@ -60,6 +60,8 @@ References: `RR0011AddArgumentNameTests.cs`, `AddOrRemoveArgumentNameRefactoring
 
 ## Metadata Example
 
+Confirm `Id`, `Identifier`, `Title`, and `OptionKey` with the user before writing XML (see hard gate in `SKILL.md`).
+
 ```xml
 <Refactoring Id="RR0011" Identifier="AddArgumentName" Title="Add argument name">
   <OptionKey>add_argument_name</OptionKey>


### PR DESCRIPTION
## Summary
- Add a **Confirm metadata parameters** hard gate to `add-analyzer`, `add-refactoring`, and `add-compiler-diagnostic-fix`.
- Agents must ask (via `AskQuestion` when available) for values such as `DefaultSeverity` and `IsEnabledByDefault` before editing XML / codegen / implementation.
- Skip only when the issue or user message already states the value.

## Test plan
- [ ] Read updated `SKILL.md` files; confirm hard-gate language and parameter tables
- [ ] Optional: start an \"add analyzer\" agent task without stating severity and verify it asks first


Made with [Cursor](https://cursor.com)