### PR TITLE
[5.0] Enable nullable annotations on Common and Workspaces.Common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- Enable nullable annotations on `Roslynator.Common` and `Roslynator.Workspaces.Common` ([#1817](https://github.com/dotnet/roslynator/issues/1817))
+  - Source-breaking for projects that compile against this surface with nullable reference types enabled.
 - [Testing Framework] Lower Roslyn dependency of testing packages to 3.8.0 so that the Roslyn version is determined by the consumer's own `Microsoft.CodeAnalysis.*` reference instead of being forced to a fixed version ([PR](https://github.com/dotnet/roslynator/pull/1810))
   - `Roslynator.Testing.Common`, `Roslynator.Testing.CSharp`, `Roslynator.Testing.CSharp.Xunit` and `Roslynator.Testing.CSharp.MSTest` now depend on `Microsoft.CodeAnalysis.*` `>= 3.8.0` (previously `>= 4.14.0`).
   - `Roslynator.Testing.Common` no longer depends on `Roslynator.Core`.

--- a/src/Common/AbstractRequiredConfigOptionNotSetAnalyzer.cs
+++ b/src/Common/AbstractRequiredConfigOptionNotSetAnalyzer.cs
@@ -47,7 +47,7 @@ internal abstract class AbstractRequiredConfigOptionNotSetAnalyzer : DiagnosticA
 
     private static bool IsOptionSet(AnalyzerConfigOptions configOptions, ConfigOptionDescriptor option)
     {
-        return configOptions.TryGetValue(option.Key, out string _)
+        return configOptions.TryGetValue(option.Key, out string? _)
             || CodeAnalysisConfig.Instance.EditorConfig.Options.ContainsKey(option.Key);
     }
 

--- a/src/Common/ArgumentNullCheckAnalysis.cs
+++ b/src/Common/ArgumentNullCheckAnalysis.cs
@@ -10,7 +10,7 @@ namespace Roslynator.CSharp;
 
 internal readonly struct ArgumentNullCheckAnalysis
 {
-    private ArgumentNullCheckAnalysis(ArgumentNullCheckStyle style, string name, bool success)
+    private ArgumentNullCheckAnalysis(ArgumentNullCheckStyle style, string? name, bool success)
     {
         Style = style;
         Name = name;
@@ -18,7 +18,7 @@ internal readonly struct ArgumentNullCheckAnalysis
     }
 
     public ArgumentNullCheckStyle Style { get; }
-    public string Name { get; }
+    public string? Name { get; }
     public bool Success { get; }
 
     public static ArgumentNullCheckAnalysis Create(
@@ -32,13 +32,13 @@ internal readonly struct ArgumentNullCheckAnalysis
     public static ArgumentNullCheckAnalysis Create(
         StatementSyntax statement,
         SemanticModel semanticModel,
-        string name,
+        string? name,
         CancellationToken cancellationToken = default)
     {
         if (statement is IfStatementSyntax ifStatement)
         {
             var style = ArgumentNullCheckStyle.None;
-            string identifier = null;
+            string? identifier = null;
             var success = false;
 
             if (ifStatement.SingleNonBlockStatementOrDefault() is ThrowStatementSyntax throwStatement
@@ -84,11 +84,11 @@ internal readonly struct ArgumentNullCheckAnalysis
     private static ArgumentNullCheckAnalysis CreateFromArgumentNullExceptionThrowIfNullCheck(
         StatementSyntax statement,
         SemanticModel semanticModel,
-        string name,
+        string? name,
         CancellationToken cancellationToken)
     {
         var style = ArgumentNullCheckStyle.None;
-        string identifier = null;
+        string? identifier = null;
         var success = false;
 
         if (statement is ExpressionStatementSyntax expressionStatement)
@@ -139,7 +139,7 @@ internal readonly struct ArgumentNullCheckAnalysis
     public static bool IsArgumentNullCheck(
         StatementSyntax statement,
         SemanticModel semanticModel,
-        string name,
+        string? name,
         CancellationToken cancellationToken = default)
     {
         return Create(statement, semanticModel, name, cancellationToken).Success;

--- a/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/AddExceptionToDocumentationCommentAnalysis.cs
+++ b/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/AddExceptionToDocumentationCommentAnalysis.cs
@@ -18,7 +18,7 @@ internal static class AddExceptionToDocumentationCommentAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        ExpressionSyntax expression = throwStatement.Expression;
+        ExpressionSyntax? expression = throwStatement.Expression;
 
         if (expression?.IsMissing == false)
         {
@@ -36,7 +36,7 @@ internal static class AddExceptionToDocumentationCommentAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        ExpressionSyntax expression = throwExpression.Expression;
+        ExpressionSyntax? expression = throwExpression.Expression;
 
         if (expression?.IsMissing == false)
         {
@@ -64,12 +64,12 @@ internal static class AddExceptionToDocumentationCommentAnalysis
         if (IsExceptionTypeCaughtInMethod(node, typeSymbol, semanticModel, cancellationToken))
             return Fail;
 
-        ISymbol declarationSymbol = GetDeclarationSymbol(node.SpanStart, semanticModel, cancellationToken);
+        ISymbol? declarationSymbol = GetDeclarationSymbol(node.SpanStart, semanticModel, cancellationToken);
 
         if (declarationSymbol?.GetSyntax(cancellationToken) is not MemberDeclarationSyntax containingMember)
             return Fail;
 
-        DocumentationCommentTriviaSyntax comment = containingMember.GetSingleLineDocumentationComment();
+        DocumentationCommentTriviaSyntax? comment = containingMember.GetSingleLineDocumentationComment();
 
         if (comment is null)
             return Fail;
@@ -187,17 +187,17 @@ internal static class AddExceptionToDocumentationCommentAnalysis
         return false;
     }
 
-    internal static ISymbol GetDeclarationSymbol(
+    internal static ISymbol? GetDeclarationSymbol(
         int position,
         SemanticModel semanticModel,
         CancellationToken cancellationToken = default)
     {
-        ISymbol symbol = semanticModel.GetEnclosingSymbol(position, cancellationToken);
+        ISymbol? symbol = semanticModel.GetEnclosingSymbol(position, cancellationToken);
 
         return GetDeclarationSymbol(symbol);
     }
 
-    private static ISymbol GetDeclarationSymbol(ISymbol symbol)
+    private static ISymbol? GetDeclarationSymbol(ISymbol? symbol)
     {
         if (symbol is not IMethodSymbol methodSymbol)
             return null;
@@ -225,14 +225,14 @@ internal static class AddExceptionToDocumentationCommentAnalysis
     /// </summary>
     private static bool IsExceptionTypeCaughtInMethod(SyntaxNode node, ITypeSymbol exceptionSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        SyntaxNode parent = node.Parent;
+        SyntaxNode? parent = node.Parent;
         while (parent is not null)
         {
             if (parent is TryStatementSyntax tryStatement)
             {
                 foreach (CatchClauseSyntax catchClause in tryStatement.Catches)
                 {
-                    TypeSyntax exceptionType = catchClause.Declaration?.Type;
+                    TypeSyntax? exceptionType = catchClause.Declaration?.Type;
 
                     if (exceptionType is null
                         || SymbolEqualityComparer.Default.Equals(

--- a/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/AddExceptionToDocumentationCommentAnalysisResult.cs
+++ b/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/AddExceptionToDocumentationCommentAnalysisResult.cs
@@ -19,7 +19,7 @@ internal readonly struct AddExceptionToDocumentationCommentAnalysisResult
         get { return ThrowInfo is not null; }
     }
 
-    public ISymbol DeclarationSymbol
+    public ISymbol? DeclarationSymbol
     {
         get { return ThrowInfo?.DeclarationSymbol; }
     }

--- a/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/ThrowExpressionInfo.cs
+++ b/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/ThrowExpressionInfo.cs
@@ -10,16 +10,19 @@ namespace Roslynator.CSharp.Analysis.AddExceptionToDocumentationComment;
 
 internal class ThrowExpressionInfo : ThrowInfo
 {
-    internal ThrowExpressionInfo(ThrowExpressionSyntax node, ExpressionSyntax expression, ITypeSymbol exceptionSymbol, ISymbol declarationSymbol)
+    internal ThrowExpressionInfo(ThrowExpressionSyntax node, ExpressionSyntax? expression, ITypeSymbol exceptionSymbol, ISymbol declarationSymbol)
         : base(node, expression, exceptionSymbol, declarationSymbol)
     {
     }
 
-    protected override IParameterSymbol GetParameterSymbolCore(SemanticModel semanticModel, CancellationToken cancellationToken)
+    protected override IParameterSymbol? GetParameterSymbolCore(SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        SyntaxNode parent = Node.Parent;
+        SyntaxNode? parent = Node.Parent;
 
-        if (!parent.IsKind(SyntaxKind.CoalesceExpression))
+        if (parent?.IsKind(SyntaxKind.CoalesceExpression) != true)
+            return null;
+
+        if (parent.Parent is null)
             return null;
 
         SimpleAssignmentExpressionInfo simpleAssignment = SyntaxInfo.SimpleAssignmentExpressionInfo(parent.Parent);
@@ -27,7 +30,7 @@ internal class ThrowExpressionInfo : ThrowInfo
         if (!simpleAssignment.Success)
             return null;
 
-        ISymbol leftSymbol = semanticModel.GetSymbol(simpleAssignment.Left, cancellationToken);
+        ISymbol? leftSymbol = semanticModel.GetSymbol(simpleAssignment.Left, cancellationToken);
 
         if (leftSymbol?.Kind != SymbolKind.Parameter)
             return null;

--- a/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/ThrowInfo.cs
+++ b/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/ThrowInfo.cs
@@ -9,7 +9,7 @@ namespace Roslynator.CSharp.Analysis.AddExceptionToDocumentationComment;
 
 internal abstract class ThrowInfo
 {
-    protected ThrowInfo(SyntaxNode node, ExpressionSyntax expression, ITypeSymbol exceptionSymbol, ISymbol declarationSymbol)
+    protected ThrowInfo(SyntaxNode node, ExpressionSyntax? expression, ITypeSymbol exceptionSymbol, ISymbol declarationSymbol)
     {
         Node = node;
         Expression = expression;
@@ -21,7 +21,7 @@ internal abstract class ThrowInfo
 
     public ITypeSymbol ExceptionSymbol { get; }
 
-    public ExpressionSyntax Expression { get; }
+    public ExpressionSyntax? Expression { get; }
 
     public ISymbol DeclarationSymbol { get; }
 
@@ -38,7 +38,7 @@ internal abstract class ThrowInfo
         }
     }
 
-    public IParameterSymbol GetParameterSymbol(
+    public IParameterSymbol? GetParameterSymbol(
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
@@ -52,5 +52,5 @@ internal abstract class ThrowInfo
         }
     }
 
-    protected abstract IParameterSymbol GetParameterSymbolCore(SemanticModel semanticModel, CancellationToken cancellationToken);
+    protected abstract IParameterSymbol? GetParameterSymbolCore(SemanticModel semanticModel, CancellationToken cancellationToken);
 }

--- a/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/ThrowStatementInfo.cs
+++ b/src/Common/CSharp/Analysis/AddExceptionToDocumentationComment/ThrowStatementInfo.cs
@@ -9,16 +9,16 @@ namespace Roslynator.CSharp.Analysis.AddExceptionToDocumentationComment;
 
 internal class ThrowStatementInfo : ThrowInfo
 {
-    internal ThrowStatementInfo(ThrowStatementSyntax node, ExpressionSyntax expression, ITypeSymbol exceptionSymbol, ISymbol declarationSymbol)
+    internal ThrowStatementInfo(ThrowStatementSyntax node, ExpressionSyntax? expression, ITypeSymbol exceptionSymbol, ISymbol declarationSymbol)
         : base(node, expression, exceptionSymbol, declarationSymbol)
     {
     }
 
-    protected override IParameterSymbol GetParameterSymbolCore(
+    protected override IParameterSymbol? GetParameterSymbolCore(
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        SyntaxNode parent = Node.Parent;
+        SyntaxNode? parent = Node.Parent;
 
         if (parent is null)
             return null;
@@ -36,12 +36,12 @@ internal class ThrowStatementInfo : ThrowInfo
 
         var equalsExpression = (BinaryExpressionSyntax)condition;
 
-        ExpressionSyntax left = equalsExpression.Left;
+        ExpressionSyntax? left = equalsExpression.Left;
 
         if (left is null)
             return null;
 
-        ISymbol leftSymbol = semanticModel.GetSymbol(left, cancellationToken);
+        ISymbol? leftSymbol = semanticModel.GetSymbol(left, cancellationToken);
 
         if (leftSymbol?.Kind != SymbolKind.Parameter)
             return null;

--- a/src/Common/CSharp/Analysis/BlockExpressionAnalysis.cs
+++ b/src/Common/CSharp/Analysis/BlockExpressionAnalysis.cs
@@ -8,7 +8,7 @@ namespace Roslynator.CSharp.Analysis;
 
 internal readonly struct BlockExpressionAnalysis
 {
-    private BlockExpressionAnalysis(StatementSyntax statement, ExpressionSyntax expression, SyntaxToken semicolonToken, SyntaxToken returnOrThrowKeyword)
+    private BlockExpressionAnalysis(StatementSyntax? statement, ExpressionSyntax? expression, SyntaxToken semicolonToken, SyntaxToken returnOrThrowKeyword)
     {
         Statement = statement;
         Expression = expression;
@@ -16,15 +16,15 @@ internal readonly struct BlockExpressionAnalysis
         ReturnOrThrowKeyword = returnOrThrowKeyword;
     }
 
-    public StatementSyntax Statement { get; }
+    public StatementSyntax? Statement { get; }
 
-    public ExpressionSyntax Expression { get; }
+    public ExpressionSyntax? Expression { get; }
 
     public SyntaxToken SemicolonToken { get; }
 
     public SyntaxToken ReturnOrThrowKeyword { get; }
 
-    public BlockSyntax Block => (Statement is not null) ? (BlockSyntax)Statement.Parent : default;
+    public BlockSyntax? Block => (Statement is not null) ? (BlockSyntax?)Statement.Parent : default;
 
     public bool Success => Expression is not null;
 
@@ -43,9 +43,9 @@ internal readonly struct BlockExpressionAnalysis
         return Create(accessor.Body);
     }
 
-    public static BlockExpressionAnalysis Create(BlockSyntax block, bool allowExpressionStatement = true)
+    public static BlockExpressionAnalysis Create(BlockSyntax? block, bool allowExpressionStatement = true)
     {
-        StatementSyntax statement = block?.Statements.SingleOrDefault(shouldThrow: false);
+        StatementSyntax? statement = block?.Statements.SingleOrDefault(shouldThrow: false);
 
         if (statement is null)
             return default;

--- a/src/Common/CSharp/Analysis/CallExtensionMethodAsInstanceMethodAnalysis.cs
+++ b/src/Common/CSharp/Analysis/CallExtensionMethodAsInstanceMethodAnalysis.cs
@@ -21,7 +21,7 @@ public static class CallExtensionMethodAsInstanceMethodAnalysis
         bool allowAnyExpression = false,
         CancellationToken cancellationToken = default)
     {
-        ExpressionSyntax expression = invocationExpression
+        ExpressionSyntax? expression = invocationExpression
             .ArgumentList?
             .Arguments
             .FirstOrDefault()?
@@ -48,7 +48,7 @@ public static class CallExtensionMethodAsInstanceMethodAnalysis
             }
         }
 
-        IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(invocationExpression, cancellationToken);
+        IMethodSymbol? methodSymbol = semanticModel.GetMethodSymbol(invocationExpression, cancellationToken);
 
         if (methodSymbol is null)
             return Fail;
@@ -56,7 +56,7 @@ public static class CallExtensionMethodAsInstanceMethodAnalysis
         if (!methodSymbol.IsOrdinaryExtensionMethod())
             return Fail;
 
-        InvocationExpressionSyntax newInvocationExpression = GetNewInvocation(invocationExpression);
+        InvocationExpressionSyntax? newInvocationExpression = GetNewInvocation(invocationExpression);
 
         if (newInvocationExpression is null)
             return Fail;
@@ -82,18 +82,18 @@ public static class CallExtensionMethodAsInstanceMethodAnalysis
             case SyntaxKind.SimpleMemberAccessExpression:
                 return ((MemberAccessExpressionSyntax)expression).Name;
             default:
-                return null;
+                return default;
         }
     }
 
-    private static InvocationExpressionSyntax GetNewInvocation(InvocationExpressionSyntax invocation)
+    private static InvocationExpressionSyntax? GetNewInvocation(InvocationExpressionSyntax invocation)
     {
         ExpressionSyntax expression = invocation.Expression;
         ArgumentListSyntax argumentList = invocation.ArgumentList;
         SeparatedSyntaxList<ArgumentSyntax> arguments = argumentList.Arguments;
         ArgumentSyntax argument = arguments[0];
 
-        MemberAccessExpressionSyntax newMemberAccess = CreateNewMemberAccessExpression();
+        MemberAccessExpressionSyntax? newMemberAccess = CreateNewMemberAccessExpression();
 
         if (newMemberAccess is null)
             return null;
@@ -102,7 +102,7 @@ public static class CallExtensionMethodAsInstanceMethodAnalysis
             .WithExpression(newMemberAccess)
             .WithArgumentList(argumentList.WithArguments(arguments.Remove(argument)));
 
-        MemberAccessExpressionSyntax CreateNewMemberAccessExpression()
+        MemberAccessExpressionSyntax? CreateNewMemberAccessExpression()
         {
             switch (expression.Kind())
             {

--- a/src/Common/CSharp/Analysis/CallExtensionMethodAsInstanceMethodAnalysisResult.cs
+++ b/src/Common/CSharp/Analysis/CallExtensionMethodAsInstanceMethodAnalysisResult.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -19,11 +18,11 @@ public readonly struct CallExtensionMethodAsInstanceMethodAnalysisResult : IEqua
         MethodSymbol = methodSymbol;
     }
 
-    public InvocationExpressionSyntax InvocationExpression { get; }
+    public InvocationExpressionSyntax? InvocationExpression { get; }
 
-    public InvocationExpressionSyntax NewInvocationExpression { get; }
+    public InvocationExpressionSyntax? NewInvocationExpression { get; }
 
-    public IMethodSymbol MethodSymbol { get; }
+    public IMethodSymbol? MethodSymbol { get; }
 
     public bool Success
     {
@@ -42,9 +41,9 @@ public readonly struct CallExtensionMethodAsInstanceMethodAnalysisResult : IEqua
 
     public bool Equals(CallExtensionMethodAsInstanceMethodAnalysisResult other)
     {
-        return EqualityComparer<InvocationExpressionSyntax>.Default.Equals(InvocationExpression, other.InvocationExpression)
-            && EqualityComparer<InvocationExpressionSyntax>.Default.Equals(NewInvocationExpression, other.NewInvocationExpression)
-            && EqualityComparer<IMethodSymbol>.Default.Equals(MethodSymbol, other.MethodSymbol);
+        return InvocationExpression == other.InvocationExpression
+            && NewInvocationExpression == other.NewInvocationExpression
+            && MethodSymbol == other.MethodSymbol;
     }
 
     public override int GetHashCode()

--- a/src/Common/CSharp/Analysis/ChangeAccessibilityAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ChangeAccessibilityAnalysis.cs
@@ -145,9 +145,9 @@ internal static class ChangeAccessibilityAnalysis
         return valid;
     }
 
-    public static ISymbol GetBaseSymbolOrDefault(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
+    public static ISymbol? GetBaseSymbolOrDefault(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        ISymbol symbol = GetDeclaredSymbol();
+        ISymbol? symbol = GetDeclaredSymbol();
 
         if (symbol is not null)
         {
@@ -158,7 +158,7 @@ internal static class ChangeAccessibilityAnalysis
 
             if (symbol is not null)
             {
-                SyntaxNode syntax = symbol.GetSyntaxOrDefault(cancellationToken);
+                SyntaxNode? syntax = symbol.GetSyntaxOrDefault(cancellationToken);
 
                 if (syntax is not null)
                 {
@@ -173,11 +173,11 @@ internal static class ChangeAccessibilityAnalysis
 
         return null;
 
-        ISymbol GetDeclaredSymbol()
+        ISymbol? GetDeclaredSymbol()
         {
             if (node is EventFieldDeclarationSyntax eventFieldDeclaration)
             {
-                VariableDeclaratorSyntax declarator = eventFieldDeclaration.Declaration?.Variables.SingleOrDefault(shouldThrow: false);
+                VariableDeclaratorSyntax? declarator = eventFieldDeclaration.Declaration?.Variables.SingleOrDefault(shouldThrow: false);
 
                 if (declarator is not null)
                     return semanticModel.GetDeclaredSymbol(declarator, cancellationToken);
@@ -202,7 +202,7 @@ internal static class ChangeAccessibilityAnalysis
             {
                 foreach (VariableDeclaratorSyntax declarator in eventFieldDeclaration.Declaration.Variables)
                 {
-                    var symbol = (IEventSymbol)semanticModel.GetDeclaredSymbol(declarator, cancellationToken);
+                    var symbol = (IEventSymbol?)semanticModel.GetDeclaredSymbol(declarator, cancellationToken);
 
                     if (symbol?
                         .BaseOverriddenEvent()?

--- a/src/Common/CSharp/Analysis/ConvertHasFlagCallToBitwiseOperationAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ConvertHasFlagCallToBitwiseOperationAnalysis.cs
@@ -37,17 +37,17 @@ internal static class ConvertHasFlagCallToBitwiseOperationAnalysis
         if (CSharpUtility.IsConditionallyAccessed(invocationInfo.InvocationExpression))
             return false;
 
-        IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(invocationInfo.InvocationExpression, cancellationToken);
+        IMethodSymbol? methodSymbol = semanticModel.GetMethodSymbol(invocationInfo.InvocationExpression, cancellationToken);
 
         if (methodSymbol?.IsStatic == false
             && methodSymbol.IsReturnType(SpecialType.System_Boolean)
             && methodSymbol.HasSingleParameter(SpecialType.System_Enum)
             && methodSymbol.IsContainingType(SpecialType.System_Enum)
-            && !semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken).HasMetadataName(MetadataNames.System_Enum))
+            && semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken)?.HasMetadataName(MetadataNames.System_Enum) != true)
         {
             ExpressionSyntax expression = invocationInfo.Arguments.Single().Expression;
 
-            if (!semanticModel.GetTypeSymbol(expression, cancellationToken).HasMetadataName(MetadataNames.System_Enum)
+            if (semanticModel.GetTypeSymbol(expression, cancellationToken)?.HasMetadataName(MetadataNames.System_Enum) != true
                 && semanticModel.HasConstantValue(expression, cancellationToken))
             {
                 return true;

--- a/src/Common/CSharp/Analysis/ConvertLambdaExpressionBodyToExpressionBodyAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ConvertLambdaExpressionBodyToExpressionBodyAnalysis.cs
@@ -18,12 +18,12 @@ internal static class ConvertLambdaExpressionBodyToExpressionBodyAnalysis
 
         var block = (BlockSyntax)body;
 
-        StatementSyntax statement = block.Statements.SingleOrDefault(shouldThrow: false);
+        StatementSyntax? statement = block.Statements.SingleOrDefault(shouldThrow: false);
 
         if (statement is null)
             return false;
 
-        ExpressionSyntax expression = GetExpression(statement);
+        ExpressionSyntax? expression = GetExpression(statement);
 
         return expression?.IsSingleLine() == true
             && lambda
@@ -34,7 +34,7 @@ internal static class ConvertLambdaExpressionBodyToExpressionBodyAnalysis
                 .All(f => f.IsWhitespaceOrEndOfLineTrivia());
     }
 
-    private static ExpressionSyntax GetExpression(StatementSyntax statement)
+    private static ExpressionSyntax? GetExpression(StatementSyntax statement)
     {
         switch (statement.Kind())
         {

--- a/src/Common/CSharp/Analysis/ConvertMethodGroupToAnonymousFunctionAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ConvertMethodGroupToAnonymousFunctionAnalysis.cs
@@ -13,7 +13,7 @@ public static class ConvertMethodGroupToAnonymousFunctionAnalysis
     {
         if (CanBeMethodGroup(identifierName))
         {
-            IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(identifierName, cancellationToken);
+            IMethodSymbol? methodSymbol = semanticModel.GetMethodSymbol(identifierName, cancellationToken);
 
             if (methodSymbol is not null)
                 return true;
@@ -26,7 +26,7 @@ public static class ConvertMethodGroupToAnonymousFunctionAnalysis
     {
         if (CanBeMethodGroup(memberAccessExpression))
         {
-            IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(memberAccessExpression, cancellationToken);
+            IMethodSymbol? methodSymbol = semanticModel.GetMethodSymbol(memberAccessExpression, cancellationToken);
 
             if (methodSymbol is not null)
                 return true;
@@ -39,7 +39,10 @@ public static class ConvertMethodGroupToAnonymousFunctionAnalysis
     {
         expression = expression.WalkUpParentheses();
 
-        SyntaxNode parent = expression.Parent;
+        SyntaxNode? parent = expression.Parent;
+
+        if (parent is null)
+            return false;
 
         switch (parent.Kind())
         {

--- a/src/Common/CSharp/Analysis/ExpandExpressionBodyAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ExpandExpressionBodyAnalysis.cs
@@ -10,7 +10,7 @@ internal static class ExpandExpressionBodyAnalysis
 {
     public static bool IsFixable(ArrowExpressionClauseSyntax arrowExpressionClause)
     {
-        SyntaxNode parent = arrowExpressionClause.Parent;
+        SyntaxNode? parent = arrowExpressionClause.Parent;
 
         return parent is not null
             && CSharpFacts.CanHaveExpressionBody(parent.Kind());

--- a/src/Common/CSharp/Analysis/GenerateBaseConstructorsAnalysis.cs
+++ b/src/Common/CSharp/Analysis/GenerateBaseConstructorsAnalysis.cs
@@ -12,16 +12,16 @@ namespace Roslynator.CSharp.Analysis;
 
 internal static class GenerateBaseConstructorsAnalysis
 {
-    public static List<IMethodSymbol> GetMissingBaseConstructors(
+    public static List<IMethodSymbol>? GetMissingBaseConstructors(
         ClassDeclarationSyntax classDeclaration,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        INamedTypeSymbol symbol = semanticModel.GetDeclaredSymbol(classDeclaration, cancellationToken);
+        INamedTypeSymbol? symbol = semanticModel.GetDeclaredSymbol(classDeclaration, cancellationToken);
 
         if (symbol?.IsStatic == false)
         {
-            INamedTypeSymbol baseSymbol = symbol.BaseType;
+            INamedTypeSymbol? baseSymbol = symbol.BaseType;
 
             if (baseSymbol?.IsObject() == false)
                 return GetMissingBaseConstructors(symbol, baseSymbol);
@@ -30,26 +30,26 @@ internal static class GenerateBaseConstructorsAnalysis
         return null;
     }
 
-    public static List<IMethodSymbol> GetMissingBaseConstructors(
+    public static List<IMethodSymbol>? GetMissingBaseConstructors(
         RecordDeclarationSyntax recordDeclaration,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        INamedTypeSymbol symbol = semanticModel.GetDeclaredSymbol(recordDeclaration, cancellationToken);
+        INamedTypeSymbol? symbol = semanticModel.GetDeclaredSymbol(recordDeclaration, cancellationToken);
 
-        INamedTypeSymbol baseSymbol = symbol?.BaseType;
+        INamedTypeSymbol? baseSymbol = symbol?.BaseType;
 
         if (baseSymbol?.IsObject() == false)
-            return GetMissingBaseConstructors(symbol, baseSymbol);
+            return GetMissingBaseConstructors(symbol!, baseSymbol);
 
         return null;
     }
 
-    private static List<IMethodSymbol> GetMissingBaseConstructors(INamedTypeSymbol symbol, INamedTypeSymbol baseSymbol)
+    private static List<IMethodSymbol>? GetMissingBaseConstructors(INamedTypeSymbol symbol, INamedTypeSymbol baseSymbol)
     {
         ImmutableArray<IMethodSymbol> constructors = symbol.InstanceConstructors.RemoveAll(f => f.IsImplicitlyDeclared);
 
-        List<IMethodSymbol> missing = null;
+        List<IMethodSymbol>? missing = null;
 
         foreach (IMethodSymbol baseConstructor in GetBaseConstructors(baseSymbol))
         {
@@ -89,7 +89,7 @@ internal static class GenerateBaseConstructorsAnalysis
             && constructors[0].IsImplicitlyDeclared
             && baseSymbol.BaseType?.IsObject() == false)
         {
-            baseSymbol = baseSymbol.BaseType;
+            baseSymbol = baseSymbol.BaseType!;
 
             constructors = baseSymbol.InstanceConstructors;
         }
@@ -109,7 +109,7 @@ internal static class GenerateBaseConstructorsAnalysis
     {
         public static ParametersComparer Instance { get; } = new();
 
-        public override bool Equals(IMethodSymbol x, IMethodSymbol y)
+        public override bool Equals(IMethodSymbol? x, IMethodSymbol? y)
         {
             if (object.ReferenceEquals(x, y))
                 return true;
@@ -135,7 +135,7 @@ internal static class GenerateBaseConstructorsAnalysis
             return true;
         }
 
-        public override int GetHashCode(IMethodSymbol obj)
+        public override int GetHashCode(IMethodSymbol? obj)
         {
             return 0;
         }

--- a/src/Common/CSharp/Analysis/If/IfAnalysis.cs
+++ b/src/Common/CSharp/Analysis/If/IfAnalysis.cs
@@ -47,19 +47,19 @@ internal abstract class IfAnalysis
         if (!ifStatement.IsTopmostIf())
             return Empty;
 
-        ExpressionSyntax condition = ifStatement.Condition?.WalkDownParentheses();
+        ExpressionSyntax? condition = ifStatement.Condition?.WalkDownParentheses();
 
         if (condition is null)
             return Empty;
 
-        ElseClauseSyntax elseClause = ifStatement.Else;
+        ElseClauseSyntax? elseClause = ifStatement.Else;
 
         if (elseClause is not null)
         {
             if (!CheckDirectivesAndComments(ifStatement, options))
                 return Empty;
 
-            StatementSyntax statement1 = ifStatement.SingleNonBlockStatementOrDefault();
+            StatementSyntax? statement1 = ifStatement.SingleNonBlockStatementOrDefault();
 
             if (statement1 is null)
                 return Empty;
@@ -71,7 +71,7 @@ internal abstract class IfAnalysis
                 SyntaxKind.ReturnStatement,
                 SyntaxKind.YieldReturnStatement))
             {
-                StatementSyntax statement2 = elseClause.SingleNonBlockStatementOrDefault();
+                StatementSyntax? statement2 = elseClause.SingleNonBlockStatementOrDefault();
 
                 if (statement2?.Kind() == kind1)
                 {
@@ -127,8 +127,8 @@ internal abstract class IfAnalysis
     private static ImmutableArray<IfAnalysis> Analyze(
         IfStatementSyntax ifStatement,
         ExpressionSyntax condition,
-        ExpressionSyntax expression1,
-        ExpressionSyntax expression2,
+        ExpressionSyntax? expression1,
+        ExpressionSyntax? expression2,
         IfAnalysisOptions options,
         bool isYield,
         SemanticModel semanticModel,
@@ -171,7 +171,7 @@ internal abstract class IfAnalysis
 
             if (nullCheck.Success)
             {
-                IfAnalysis refactoring = CreateIfToReturnStatement(
+                IfAnalysis? refactoring = CreateIfToReturnStatement(
                     ifStatement,
                     (nullCheck.IsCheckingNull) ? expression2 : expression1,
                     (nullCheck.IsCheckingNull) ? expression1 : expression2,
@@ -186,7 +186,7 @@ internal abstract class IfAnalysis
             }
         }
 
-        IfToReturnWithBooleanExpressionAnalysis ifToReturnWithBooleanExpression = null;
+        IfToReturnWithBooleanExpressionAnalysis? ifToReturnWithBooleanExpression = null;
 
         if (options.UseBooleanExpression
             && (IsBooleanLiteralExpression(expression1.Kind()) || IsBooleanLiteralExpression(expression2.Kind()))
@@ -196,7 +196,7 @@ internal abstract class IfAnalysis
             ifToReturnWithBooleanExpression = IfToReturnWithBooleanExpressionAnalysis.Create(ifStatement, expression1, expression2, semanticModel, isYield);
         }
 
-        IfToReturnWithConditionalExpressionAnalysis ifToReturnWithConditionalExpression = null;
+        IfToReturnWithConditionalExpressionAnalysis? ifToReturnWithConditionalExpression = null;
 
         if (options.UseConditionalExpression
             && (!IsBooleanLiteralExpression(expression1.Kind()) || !IsBooleanLiteralExpression(expression2.Kind()))
@@ -209,7 +209,7 @@ internal abstract class IfAnalysis
         return ToImmutableArray(ifToReturnWithBooleanExpression, ifToReturnWithConditionalExpression);
     }
 
-    private static IfAnalysis CreateIfToReturnStatement(
+    private static IfAnalysis? CreateIfToReturnStatement(
         IfStatementSyntax ifStatement,
         ExpressionSyntax expression1,
         ExpressionSyntax expression2,
@@ -225,14 +225,18 @@ internal abstract class IfAnalysis
             return CreateIfToReturnStatement(isNullable: false);
         }
 
-        expression1 = GetNullableOfTValueProperty(expression1, semanticModel, cancellationToken);
+        ExpressionSyntax? valueProperty = GetNullableOfTValueProperty(expression1, semanticModel, cancellationToken);
 
-        if (AreEquivalent(nullCheck.Expression, expression1))
+        if (valueProperty is not null
+            && AreEquivalent(nullCheck.Expression, valueProperty))
+        {
+            expression1 = valueProperty;
             return CreateIfToReturnStatement(isNullable: true);
+        }
 
         return null;
 
-        IfAnalysis CreateIfToReturnStatement(bool isNullable)
+        IfAnalysis? CreateIfToReturnStatement(bool isNullable)
         {
             if (!isNullable
                 && expression2.Kind() == SyntaxKind.NullLiteralExpression)
@@ -296,7 +300,7 @@ internal abstract class IfAnalysis
 
             if (nullCheck.Success)
             {
-                IfAnalysis refactoring = CreateIfToAssignment(
+                IfAnalysis? refactoring = CreateIfToAssignment(
                     ifStatement,
                     left1,
                     (nullCheck.IsCheckingNull) ? right2 : right1,
@@ -321,7 +325,7 @@ internal abstract class IfAnalysis
         return Empty;
     }
 
-    private static IfAnalysis CreateIfToAssignment(
+    private static IfAnalysis? CreateIfToAssignment(
         IfStatementSyntax ifStatement,
         ExpressionSyntax left,
         ExpressionSyntax expression1,
@@ -337,20 +341,29 @@ internal abstract class IfAnalysis
             return CreateIfToAssignment(isNullable: false);
         }
 
-        expression1 = GetNullableOfTValueProperty(expression1, semanticModel, cancellationToken);
+        ExpressionSyntax? valueProperty = GetNullableOfTValueProperty(expression1, semanticModel, cancellationToken);
 
-        if (AreEquivalent(nullCheck.Expression, expression1))
+        if (valueProperty is not null
+            && AreEquivalent(nullCheck.Expression, valueProperty))
+        {
+            expression1 = valueProperty;
             return CreateIfToAssignment(isNullable: true);
+        }
 
         return null;
 
-        IfAnalysis CreateIfToAssignment(bool isNullable)
+        IfAnalysis? CreateIfToAssignment(bool isNullable)
         {
             if (!isNullable
                 && expression2.Kind() == SyntaxKind.NullLiteralExpression)
             {
                 if (options.UseExpression)
-                    return new IfElseToAssignmentWithExpressionAnalysis(ifStatement, expression1.FirstAncestor<ExpressionStatementSyntax>(), semanticModel);
+                {
+                    if (expression1.FirstAncestor<ExpressionStatementSyntax>() is not { } expressionStatement)
+                        return null;
+
+                    return new IfElseToAssignmentWithExpressionAnalysis(ifStatement, expressionStatement, semanticModel);
+                }
             }
             else if (options.UseCoalesceExpression)
             {
@@ -418,7 +431,7 @@ internal abstract class IfAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        VariableDeclaratorSyntax declarator = localDeclarationStatement
+        VariableDeclaratorSyntax? declarator = localDeclarationStatement
             .Declaration?
             .Variables
             .SingleOrDefault(shouldThrow: false);
@@ -426,17 +439,27 @@ internal abstract class IfAnalysis
         if (declarator is null)
             return Empty;
 
-        ElseClauseSyntax elseClause = ifStatement.Else;
+        ElseClauseSyntax? elseClause = ifStatement.Else;
 
         if (elseClause?.Statement?.IsKind(SyntaxKind.IfStatement) != false)
             return Empty;
 
-        SimpleAssignmentStatementInfo assignment1 = SyntaxInfo.SimpleAssignmentStatementInfo(ifStatement.SingleNonBlockStatementOrDefault());
+        StatementSyntax? statement1 = ifStatement.SingleNonBlockStatementOrDefault();
+
+        if (statement1 is null)
+            return Empty;
+
+        SimpleAssignmentStatementInfo assignment1 = SyntaxInfo.SimpleAssignmentStatementInfo(statement1);
 
         if (!assignment1.Success)
             return Empty;
 
-        SimpleAssignmentStatementInfo assignment2 = SyntaxInfo.SimpleAssignmentStatementInfo(elseClause.SingleNonBlockStatementOrDefault());
+        StatementSyntax? statement2 = elseClause.SingleNonBlockStatementOrDefault();
+
+        if (statement2 is null)
+            return Empty;
+
+        SimpleAssignmentStatementInfo assignment2 = SyntaxInfo.SimpleAssignmentStatementInfo(statement2);
 
         if (!assignment2.Success)
             return Empty;
@@ -480,21 +503,31 @@ internal abstract class IfAnalysis
         if (!assignment.Success)
             return Empty;
 
-        SimpleAssignmentStatementInfo assignment1 = SyntaxInfo.SimpleAssignmentStatementInfo(ifStatement.SingleNonBlockStatementOrDefault());
+        StatementSyntax? ifStatementBody = ifStatement.SingleNonBlockStatementOrDefault();
+
+        if (ifStatementBody is null)
+            return Empty;
+
+        SimpleAssignmentStatementInfo assignment1 = SyntaxInfo.SimpleAssignmentStatementInfo(ifStatementBody);
 
         if (!assignment1.Success)
             return Empty;
 
-        ElseClauseSyntax elseClause = ifStatement.Else;
+        ElseClauseSyntax? elseClause = ifStatement.Else;
 
         ExpressionSyntax whenFalse;
 
         if (elseClause is not null)
         {
-            if (elseClause.Statement.IsKind(SyntaxKind.IfStatement))
+            if (elseClause.Statement?.IsKind(SyntaxKind.IfStatement) == true)
                 return Empty;
 
-            SimpleAssignmentStatementInfo assignment2 = SyntaxInfo.SimpleAssignmentStatementInfo(elseClause.SingleNonBlockStatementOrDefault());
+            StatementSyntax? elseStatement = elseClause.SingleNonBlockStatementOrDefault();
+
+            if (elseStatement is null)
+                return Empty;
+
+            SimpleAssignmentStatementInfo assignment2 = SyntaxInfo.SimpleAssignmentStatementInfo(elseStatement);
 
             if (!assignment2.Success)
                 return Empty;
@@ -540,12 +573,12 @@ internal abstract class IfAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        ExpressionSyntax condition = ifStatement.Condition?.WalkDownParentheses();
+        ExpressionSyntax? condition = ifStatement.Condition?.WalkDownParentheses();
 
         if (condition?.IsMissing != false)
             return Empty;
 
-        StatementSyntax statement = ifStatement.SingleNonBlockStatementOrDefault();
+        StatementSyntax? statement = ifStatement.SingleNonBlockStatementOrDefault();
 
         if (statement?.IsKind(SyntaxKind.ReturnStatement) != true)
             return Empty;
@@ -569,7 +602,7 @@ internal abstract class IfAnalysis
         return ImmutableArray.Create(this);
     }
 
-    private static ImmutableArray<IfAnalysis> ToImmutableArray(IfAnalysis refactoring1, IfAnalysis refactoring2)
+    private static ImmutableArray<IfAnalysis> ToImmutableArray(IfAnalysis? refactoring1, IfAnalysis? refactoring2)
     {
         if (refactoring1 is not null)
         {
@@ -590,7 +623,7 @@ internal abstract class IfAnalysis
         return Empty;
     }
 
-    private static ExpressionSyntax GetNullableOfTValueProperty(
+    private static ExpressionSyntax? GetNullableOfTValueProperty(
         ExpressionSyntax expression,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)

--- a/src/Common/CSharp/Analysis/If/IfAnalysis.cs
+++ b/src/Common/CSharp/Analysis/If/IfAnalysis.cs
@@ -519,7 +519,7 @@ internal abstract class IfAnalysis
 
         if (elseClause is not null)
         {
-            if (elseClause.Statement?.IsKind(SyntaxKind.IfStatement) == true)
+            if (elseClause.Statement.IsKind(SyntaxKind.IfStatement))
                 return Empty;
 
             StatementSyntax? elseStatement = elseClause.SingleNonBlockStatementOrDefault();

--- a/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
@@ -46,7 +46,11 @@ internal static class ReduceIfNestingAnalysis
             return Fail(ifStatement);
 
         SyntaxNode node = statementsInfo.Parent;
-        SyntaxNode parent = node.Parent;
+        SyntaxNode? parent = node.Parent;
+
+        if (parent is null)
+            return Fail(ifStatement);
+
         SyntaxKind parentKind = parent.Kind();
 
         SyntaxList<StatementSyntax> statements = statementsInfo.Statements;
@@ -274,14 +278,19 @@ internal static class ReduceIfNestingAnalysis
 
                 var elseClause = (ElseClauseSyntax)parent;
 
-                return AnalyzeCore(elseClause.GetTopmostIf(), semanticModel, jumpKind, options, cancellationToken);
+                IfStatementSyntax? topmostIf = elseClause.GetTopmostIf();
+
+                if (topmostIf is null)
+                    return Fail(parent);
+
+                return AnalyzeCore(topmostIf, semanticModel, jumpKind, options, cancellationToken);
             }
         }
 
         return Fail(parent);
     }
 
-    private static bool IsNestedFix(SyntaxNode node, SemanticModel semanticModel, ReduceIfNestingOptions options, CancellationToken cancellationToken)
+    private static bool IsNestedFix(SyntaxNode? node, SemanticModel semanticModel, ReduceIfNestingOptions options, CancellationToken cancellationToken)
     {
         options |= ReduceIfNestingOptions.AllowNestedFix;
 
@@ -295,6 +304,9 @@ internal static class ReduceIfNestingAnalysis
                     return true;
 
                 node = analysis.TopNode;
+
+                if (node is null)
+                    return false;
             }
 
             if (node is MemberDeclarationSyntax)
@@ -376,7 +388,7 @@ internal static class ReduceIfNestingAnalysis
             }
             case ReturnStatementSyntax returnStatement:
             {
-                ExpressionSyntax expression = returnStatement.Expression;
+                ExpressionSyntax? expression = returnStatement.Expression;
 
                 if (expression is null)
                     return SyntaxKind.ReturnStatement;
@@ -396,7 +408,7 @@ internal static class ReduceIfNestingAnalysis
             }
             case ThrowStatementSyntax throwStatement:
             {
-                ExpressionSyntax expression = throwStatement.Expression;
+                ExpressionSyntax? expression = throwStatement.Expression;
 
                 if (expression is null)
                     return SyntaxKind.ThrowStatement;

--- a/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysisResult.cs
+++ b/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysisResult.cs
@@ -29,7 +29,7 @@ internal readonly struct ReduceIfNestingAnalysisResult
 
     public SyntaxKind JumpKind { get; }
 
-    public SyntaxNode TopNode { get; }
+    public SyntaxNode? TopNode { get; }
 
     public bool Success
     {

--- a/src/Common/CSharp/Analysis/RemoveAsyncAwaitAnalysis.cs
+++ b/src/Common/CSharp/Analysis/RemoveAsyncAwaitAnalysis.cs
@@ -27,16 +27,16 @@ internal readonly struct RemoveAsyncAwaitAnalysis
 
     public bool Success => AwaitExpression is not null || Walker?.AwaitExpressions.Count > 0;
 
-    public AwaitExpressionSyntax AwaitExpression { get; }
+    public AwaitExpressionSyntax? AwaitExpression { get; }
 
-    public AwaitExpressionWalker Walker { get; }
+    public AwaitExpressionWalker? Walker { get; }
 
     public static RemoveAsyncAwaitAnalysis Create(
         MethodDeclarationSyntax methodDeclaration,
         SemanticModel semanticModel,
         CancellationToken cancellationToken = default)
     {
-        BlockSyntax body = methodDeclaration.Body;
+        BlockSyntax? body = methodDeclaration.Body;
 
         if (body is not null)
         {
@@ -44,7 +44,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
         }
         else
         {
-            ArrowExpressionClauseSyntax expressionBody = methodDeclaration.ExpressionBody;
+            ArrowExpressionClauseSyntax? expressionBody = methodDeclaration.ExpressionBody;
 
             if (expressionBody is not null)
                 return AnalyzeExpressionBody(methodDeclaration, expressionBody, semanticModel, cancellationToken);
@@ -58,7 +58,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken = default)
     {
-        BlockSyntax body = localFunction.Body;
+        BlockSyntax? body = localFunction.Body;
 
         if (body is not null)
         {
@@ -66,7 +66,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
         }
         else
         {
-            ArrowExpressionClauseSyntax expressionBody = localFunction.ExpressionBody;
+            ArrowExpressionClauseSyntax? expressionBody = localFunction.ExpressionBody;
 
             if (expressionBody is not null)
                 return AnalyzeExpressionBody(localFunction, expressionBody, semanticModel, cancellationToken);
@@ -151,7 +151,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
     {
         SyntaxList<StatementSyntax> statements = body.Statements;
 
-        StatementSyntax statement = null;
+        StatementSyntax? statement = null;
 
         foreach (StatementSyntax s in statements)
         {
@@ -176,7 +176,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
             {
                 var returnStatement = (ReturnStatementSyntax)statement;
 
-                AwaitExpressionSyntax awaitExpression = GetAwaitExpression(returnStatement);
+                AwaitExpressionSyntax? awaitExpression = GetAwaitExpression(returnStatement);
 
                 if (awaitExpression is null)
                     return default;
@@ -279,7 +279,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
                 return false;
             }
 
-            AwaitExpressionSyntax awaitExpression = GetAwaitExpression(ifOrElse.Statement);
+            AwaitExpressionSyntax? awaitExpression = GetAwaitExpression(ifOrElse.Statement);
 
             if (awaitExpression is null)
                 return false;
@@ -304,7 +304,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
                 return false;
             }
 
-            AwaitExpressionSyntax awaitExpression = GetAwaitExpression(section.Statements.LastOrDefault());
+            AwaitExpressionSyntax? awaitExpression = GetAwaitExpression(section.Statements.LastOrDefault());
 
             if (awaitExpression is null)
                 return false;
@@ -315,7 +315,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
         return expectedCount == count;
     }
 
-    private static AwaitExpressionSyntax GetAwaitExpression(StatementSyntax statement)
+    private static AwaitExpressionSyntax? GetAwaitExpression(StatementSyntax? statement)
     {
         if (statement is null)
             return null;
@@ -339,9 +339,9 @@ internal readonly struct RemoveAsyncAwaitAnalysis
         return null;
     }
 
-    private static AwaitExpressionSyntax GetAwaitExpression(ReturnStatementSyntax returnStatement)
+    private static AwaitExpressionSyntax? GetAwaitExpression(ReturnStatementSyntax returnStatement)
     {
-        ExpressionSyntax expression = returnStatement.Expression;
+        ExpressionSyntax? expression = returnStatement.Expression;
 
         if (expression?.Kind() == SyntaxKind.AwaitExpression)
             return (AwaitExpressionSyntax)expression;
@@ -355,17 +355,17 @@ internal readonly struct RemoveAsyncAwaitAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        IMethodSymbol methodSymbol = GetMethodSymbol(node, semanticModel, cancellationToken);
+        IMethodSymbol? methodSymbol = GetMethodSymbol(node, semanticModel, cancellationToken);
 
         if (methodSymbol is null)
             return false;
 
-        ITypeSymbol returnType = methodSymbol.ReturnType;
+        ITypeSymbol? returnType = methodSymbol.ReturnType;
 
         if (returnType?.OriginalDefinition.IsAwaitable(semanticModel, node.SpanStart) != true)
             return false;
 
-        ITypeSymbol typeArgument = ((INamedTypeSymbol)returnType).TypeArguments.SingleOrDefault(shouldThrow: false);
+        ITypeSymbol? typeArgument = ((INamedTypeSymbol)returnType).TypeArguments.SingleOrDefault(shouldThrow: false);
 
         if (typeArgument is null)
             return false;
@@ -385,17 +385,17 @@ internal readonly struct RemoveAsyncAwaitAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        IMethodSymbol methodSymbol = GetMethodSymbol(node, semanticModel, cancellationToken);
+        IMethodSymbol? methodSymbol = GetMethodSymbol(node, semanticModel, cancellationToken);
 
         if (methodSymbol is null)
             return false;
 
-        ITypeSymbol returnType = methodSymbol.ReturnType;
+        ITypeSymbol? returnType = methodSymbol.ReturnType;
 
         if (returnType?.OriginalDefinition.IsAwaitable(semanticModel, node.SpanStart) != true)
             return false;
 
-        ITypeSymbol typeArgument = ((INamedTypeSymbol)returnType).TypeArguments.SingleOrDefault(shouldThrow: false);
+        ITypeSymbol? typeArgument = ((INamedTypeSymbol)returnType).TypeArguments.SingleOrDefault(shouldThrow: false);
 
         if (typeArgument is null)
             return false;
@@ -415,7 +415,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
 
         ExpressionSyntax expression = awaitExpression.Expression;
 
-        ITypeSymbol expressionTypeSymbol = semanticModel.GetTypeSymbol(expression, cancellationToken);
+        ITypeSymbol? expressionTypeSymbol = semanticModel.GetTypeSymbol(expression, cancellationToken);
 
         if (expressionTypeSymbol is null)
             return false;
@@ -429,7 +429,7 @@ internal readonly struct RemoveAsyncAwaitAnalysis
             && SymbolEqualityComparer.Default.Equals(returnType, semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken));
     }
 
-    private static IMethodSymbol GetMethodSymbol(
+    private static IMethodSymbol? GetMethodSymbol(
         SyntaxNode node,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
@@ -438,11 +438,11 @@ internal readonly struct RemoveAsyncAwaitAnalysis
         {
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.LocalFunctionStatement:
-                return (IMethodSymbol)semanticModel.GetDeclaredSymbol(node, cancellationToken);
+                return (IMethodSymbol?)semanticModel.GetDeclaredSymbol(node, cancellationToken);
             case SyntaxKind.SimpleLambdaExpression:
             case SyntaxKind.ParenthesizedLambdaExpression:
             case SyntaxKind.AnonymousMethodExpression:
-                return (IMethodSymbol)semanticModel.GetSymbol(node, cancellationToken);
+                return (IMethodSymbol?)semanticModel.GetSymbol(node, cancellationToken);
         }
 
         throw new InvalidOperationException();

--- a/src/Common/CSharp/Analysis/RemoveRedundantStatement/RemoveRedundantReturnStatementAnalysis.cs
+++ b/src/Common/CSharp/Analysis/RemoveRedundantStatement/RemoveRedundantReturnStatementAnalysis.cs
@@ -29,13 +29,13 @@ internal sealed class RemoveRedundantReturnStatementAnalysis : RemoveRedundantSt
         {
             SyntaxNode? parent = statement.Parent;
 
-            if (parent?.IsKind(SyntaxKind.Block) == true
+            if (parent.IsKind(SyntaxKind.Block)
                 && parent.Parent is IfStatementSyntax ifStatement
                 && ifStatement.IsSimpleIf())
             {
                 StatementSyntax? nextStatement = ifStatement.NextStatement();
 
-                if (nextStatement?.IsKind(SyntaxKind.ReturnStatement) == true
+                if (nextStatement.IsKind(SyntaxKind.ReturnStatement)
                     && ((ReturnStatementSyntax)nextStatement).Expression?.RawKind == expression.RawKind)
                 {
                     return true;

--- a/src/Common/CSharp/Analysis/RemoveRedundantStatement/RemoveRedundantReturnStatementAnalysis.cs
+++ b/src/Common/CSharp/Analysis/RemoveRedundantStatement/RemoveRedundantReturnStatementAnalysis.cs
@@ -16,7 +16,7 @@ internal sealed class RemoveRedundantReturnStatementAnalysis : RemoveRedundantSt
 
     public override bool IsFixable(ReturnStatementSyntax statement)
     {
-        ExpressionSyntax expression = statement.Expression;
+        ExpressionSyntax? expression = statement.Expression;
 
         if (expression is null)
             return base.IsFixable(statement);
@@ -27,15 +27,15 @@ internal sealed class RemoveRedundantReturnStatementAnalysis : RemoveRedundantSt
             SyntaxKind.TrueLiteralExpression,
             SyntaxKind.FalseLiteralExpression))
         {
-            SyntaxNode parent = statement.Parent;
+            SyntaxNode? parent = statement.Parent;
 
-            if (parent.IsKind(SyntaxKind.Block)
+            if (parent?.IsKind(SyntaxKind.Block) == true
                 && parent.Parent is IfStatementSyntax ifStatement
                 && ifStatement.IsSimpleIf())
             {
-                StatementSyntax nextStatement = ifStatement.NextStatement();
+                StatementSyntax? nextStatement = ifStatement.NextStatement();
 
-                if (nextStatement.IsKind(SyntaxKind.ReturnStatement)
+                if (nextStatement?.IsKind(SyntaxKind.ReturnStatement) == true
                     && ((ReturnStatementSyntax)nextStatement).Expression?.RawKind == expression.RawKind)
                 {
                     return true;
@@ -58,11 +58,11 @@ internal sealed class RemoveRedundantReturnStatementAnalysis : RemoveRedundantSt
             }
             case SyntaxKind.MethodDeclaration:
             {
-                return ((MethodDeclarationSyntax)block.Parent).ReturnType?.IsVoid() == true;
+                return ((MethodDeclarationSyntax?)block.Parent)?.ReturnType?.IsVoid() == true;
             }
             case SyntaxKind.LocalFunctionStatement:
             {
-                return ((LocalFunctionStatementSyntax)block.Parent).ReturnType?.IsVoid() == true;
+                return ((LocalFunctionStatementSyntax?)block.Parent)?.ReturnType?.IsVoid() == true;
             }
             case SyntaxKind.SimpleLambdaExpression:
             case SyntaxKind.ParenthesizedLambdaExpression:

--- a/src/Common/CSharp/Analysis/RemoveRedundantStatement/RemoveRedundantStatementAnalysis`1.cs
+++ b/src/Common/CSharp/Analysis/RemoveRedundantStatement/RemoveRedundantStatementAnalysis`1.cs
@@ -10,13 +10,14 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
 {
     public virtual bool IsFixable(TStatement statement)
     {
-        if (statement.Parent is not BlockSyntax block)
+        if (statement.Parent is not BlockSyntax initialBlock)
             return false;
 
-        if (!block.Statements.IsLast(statement, ignoreLocalFunctions: true))
+        if (!initialBlock.Statements.IsLast(statement, ignoreLocalFunctions: true))
             return false;
 
-        SyntaxNode parent = block.Parent;
+        BlockSyntax? block = initialBlock;
+        SyntaxNode? parent = block.Parent;
 
         StatementSyntax containingStatement = statement;
 
@@ -33,10 +34,12 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
                 {
                     containingStatement = (StatementSyntax)parent;
 
-                    block = containingStatement.Parent as BlockSyntax;
+                    BlockSyntax? nextBlock = containingStatement.Parent as BlockSyntax;
 
-                    if (block is null)
+                    if (nextBlock is null)
                         return false;
+
+                    block = nextBlock;
 
                     if (!block.Statements.IsLast(containingStatement, ignoreLocalFunctions: true))
                         return false;
@@ -53,10 +56,12 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
                 {
                     containingStatement = (TryStatementSyntax)parent;
 
-                    block = containingStatement.Parent as BlockSyntax;
+                    BlockSyntax? nextBlock = containingStatement.Parent as BlockSyntax;
 
-                    if (block is null)
+                    if (nextBlock is null)
                         return false;
+
+                    block = nextBlock;
 
                     if (!block.Statements.IsLast(containingStatement, ignoreLocalFunctions: true))
                         return false;
@@ -79,7 +84,7 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
 
     internal bool IsFixable(StatementSyntax statement, BlockSyntax block)
     {
-        SyntaxNode parent = block.Parent;
+        SyntaxNode? parent = block.Parent;
 
         StatementSyntax containingStatement = statement;
 
@@ -96,10 +101,12 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
                 {
                     containingStatement = (StatementSyntax)parent;
 
-                    block = containingStatement.Parent as BlockSyntax;
+                    BlockSyntax? nextBlock = containingStatement.Parent as BlockSyntax;
 
-                    if (block is null)
+                    if (nextBlock is null)
                         return false;
+
+                    block = nextBlock;
 
                     if (!block.Statements.IsLast(containingStatement, ignoreLocalFunctions: true))
                         return false;
@@ -116,10 +123,12 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
                 {
                     containingStatement = (TryStatementSyntax)parent;
 
-                    block = containingStatement.Parent as BlockSyntax;
+                    BlockSyntax? nextBlock = containingStatement.Parent as BlockSyntax;
 
-                    if (block is null)
+                    if (nextBlock is null)
                         return false;
+
+                    block = nextBlock;
 
                     if (!block.Statements.IsLast(containingStatement, ignoreLocalFunctions: true))
                         return false;

--- a/src/Common/CSharp/Analysis/RemoveRedundantStatement/RemoveRedundantStatementAnalysis`1.cs
+++ b/src/Common/CSharp/Analysis/RemoveRedundantStatement/RemoveRedundantStatementAnalysis`1.cs
@@ -34,9 +34,7 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
                 {
                     containingStatement = (StatementSyntax)parent;
 
-                    BlockSyntax? nextBlock = containingStatement.Parent as BlockSyntax;
-
-                    if (nextBlock is null)
+                    if (containingStatement.Parent is not BlockSyntax nextBlock)
                         return false;
 
                     block = nextBlock;
@@ -56,9 +54,7 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
                 {
                     containingStatement = (TryStatementSyntax)parent;
 
-                    BlockSyntax? nextBlock = containingStatement.Parent as BlockSyntax;
-
-                    if (nextBlock is null)
+                    if (containingStatement.Parent is not BlockSyntax nextBlock)
                         return false;
 
                     block = nextBlock;
@@ -101,9 +97,7 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
                 {
                     containingStatement = (StatementSyntax)parent;
 
-                    BlockSyntax? nextBlock = containingStatement.Parent as BlockSyntax;
-
-                    if (nextBlock is null)
+                    if (containingStatement.Parent is not BlockSyntax nextBlock)
                         return false;
 
                     block = nextBlock;
@@ -123,9 +117,7 @@ internal abstract class RemoveRedundantStatementAnalysis<TStatement> where TStat
                 {
                     containingStatement = (TryStatementSyntax)parent;
 
-                    BlockSyntax? nextBlock = containingStatement.Parent as BlockSyntax;
-
-                    if (nextBlock is null)
+                    if (containingStatement.Parent is not BlockSyntax nextBlock)
                         return false;
 
                     block = nextBlock;

--- a/src/Common/CSharp/Analysis/ReplaceAsWithCastAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ReplaceAsWithCastAnalysis.cs
@@ -19,7 +19,7 @@ internal static class ReplaceAsWithCastAnalysis
         if (!info.Success)
             return false;
 
-        ITypeSymbol typeSymbol = semanticModel.GetTypeSymbol(info.Type, cancellationToken);
+        ITypeSymbol? typeSymbol = semanticModel.GetTypeSymbol(info.Type, cancellationToken);
 
         if (typeSymbol is null)
             return false;

--- a/src/Common/CSharp/Analysis/UnnecessaryBlankLineAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UnnecessaryBlankLineAnalysis.cs
@@ -152,7 +152,7 @@ internal abstract class UnnecessaryBlankLineAnalysis
                     previousNode = catchClause;
                 }
 
-                FinallyClauseSyntax finallyClause = tryStatement.Finally;
+        FinallyClauseSyntax? finallyClause = tryStatement.Finally;
 
                 if (finallyClause is not null)
                     Analyze(context, previousNode, finallyClause);
@@ -164,11 +164,11 @@ internal abstract class UnnecessaryBlankLineAnalysis
     {
         var elseClause = (ElseClauseSyntax)context.Node;
 
-        SyntaxNode parent = elseClause.Parent;
+        SyntaxNode? parent = elseClause.Parent;
 
         if (parent is IfStatementSyntax ifStatement)
         {
-            StatementSyntax statement = ifStatement.Statement;
+            StatementSyntax? statement = ifStatement.Statement;
 
             if (statement is not null)
                 Analyze(context, statement, elseClause);
@@ -297,8 +297,7 @@ internal abstract class UnnecessaryBlankLineAnalysis
         if (IsStandardTriviaBetweenLines(trailingTrivia, leadingTrivia))
             return;
 
-        if (token
-            .SyntaxTree
+        if (token.SyntaxTree?
             .GetLineSpan(TextSpan.FromBounds(token.Span.End, node.SpanStart), context.CancellationToken)
             .GetLineCount() != 3)
         {
@@ -414,7 +413,7 @@ internal abstract class UnnecessaryBlankLineAnalysis
 
         SeparatedSyntaxList<ExpressionSyntax> expressions = initializer.Expressions;
 
-        ExpressionSyntax first = expressions.FirstOrDefault();
+        ExpressionSyntax? first = expressions.FirstOrDefault();
 
         if (first is null)
             return;
@@ -550,7 +549,7 @@ internal abstract class UnnecessaryBlankLineAnalysis
             return;
 
         int braceLine = brace.GetSpanStartLine();
-        int nodeOrTokenLine = nodeOrToken.SyntaxTree.GetLineSpan(nodeOrToken.Span).EndLine();
+        int nodeOrTokenLine = nodeOrToken.SyntaxTree!.GetLineSpan(nodeOrToken.Span).EndLine();
 
         if (braceLine - nodeOrTokenLine <= 1)
             return;

--- a/src/Common/CSharp/Analysis/UnnecessaryBlankLineAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UnnecessaryBlankLineAnalysis.cs
@@ -152,7 +152,7 @@ internal abstract class UnnecessaryBlankLineAnalysis
                     previousNode = catchClause;
                 }
 
-        FinallyClauseSyntax? finallyClause = tryStatement.Finally;
+                FinallyClauseSyntax? finallyClause = tryStatement.Finally;
 
                 if (finallyClause is not null)
                     Analyze(context, previousNode, finallyClause);

--- a/src/Common/CSharp/Analysis/UseConstantInsteadOfFieldAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseConstantInsteadOfFieldAnalysis.cs
@@ -61,7 +61,7 @@ internal static class UseConstantInsteadOfFieldAnalysis
 
         VariableDeclaratorSyntax firstDeclarator = declarators[0];
 
-        var fieldSymbol = (IFieldSymbol)semanticModel.GetDeclaredSymbol(firstDeclarator, cancellationToken);
+        var fieldSymbol = (IFieldSymbol?)semanticModel.GetDeclaredSymbol(firstDeclarator, cancellationToken);
 
         if (fieldSymbol is null)
             return false;
@@ -71,7 +71,7 @@ internal static class UseConstantInsteadOfFieldAnalysis
 
         foreach (VariableDeclaratorSyntax declarator in declarators)
         {
-            ExpressionSyntax value = declarator.Initializer?.Value;
+            ExpressionSyntax? value = declarator.Initializer?.Value;
 
             if (value is null)
                 return false;
@@ -107,7 +107,7 @@ internal static class UseConstantInsteadOfFieldAnalysis
 
                 var constructorDeclaration = (ConstructorDeclarationSyntax)syntaxReference.GetSyntax(cancellationToken);
 
-                BlockSyntax body = constructorDeclaration.Body;
+                BlockSyntax? body = constructorDeclaration.Body;
 
                 if (body is not null)
                 {

--- a/src/Common/CSharp/Analysis/UseElementAccessAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseElementAccessAnalysis.cs
@@ -22,7 +22,7 @@ internal static class UseElementAccessAnalysis
             return false;
 
         ExtensionMethodSymbolInfo reducedExtensionMethodInfo = semanticModel.GetReducedExtensionMethodInfo(invocationExpression, cancellationToken);
-        IMethodSymbol methodSymbol = reducedExtensionMethodInfo.Symbol;
+        IMethodSymbol? methodSymbol = reducedExtensionMethodInfo.Symbol;
 
         if (methodSymbol is null)
             return false;
@@ -30,7 +30,10 @@ internal static class UseElementAccessAnalysis
         if (!IsLinqElementAt(methodSymbol, allowImmutableArrayExtension: true))
             return false;
 
-        ITypeSymbol typeSymbol = semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken);
+        ITypeSymbol? typeSymbol = semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken);
+
+        if (typeSymbol is null)
+            return false;
 
         if (!HasAccessibleIndexer(typeSymbol, reducedExtensionMethodInfo.ReducedSymbolOrSymbol.ReturnType, semanticModel, invocationExpression.SpanStart))
             return false;
@@ -64,7 +67,7 @@ internal static class UseElementAccessAnalysis
             return false;
 
         ExtensionMethodSymbolInfo reducedExtensionMethodInfo = semanticModel.GetReducedExtensionMethodInfo(invocationInfo.InvocationExpression, cancellationToken);
-        IMethodSymbol methodSymbol = reducedExtensionMethodInfo.Symbol;
+        IMethodSymbol? methodSymbol = reducedExtensionMethodInfo.Symbol;
 
         if (methodSymbol is null)
             return false;
@@ -72,9 +75,10 @@ internal static class UseElementAccessAnalysis
         if (!IsLinqExtensionOfIEnumerableOfTWithoutParameters(methodSymbol, "First", allowImmutableArrayExtension: true))
             return false;
 
-        ITypeSymbol typeSymbol = semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken);
+        ITypeSymbol? typeSymbol = semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken);
 
-        return HasAccessibleIndexer(typeSymbol, reducedExtensionMethodInfo.ReducedSymbolOrSymbol.ReturnType, semanticModel, invocationInfo.InvocationExpression.SpanStart);
+        return typeSymbol is not null
+            && HasAccessibleIndexer(typeSymbol, reducedExtensionMethodInfo.ReducedSymbolOrSymbol.ReturnType, semanticModel, invocationInfo.InvocationExpression.SpanStart);
     }
 
     public static bool IsFixableLast(
@@ -92,7 +96,7 @@ internal static class UseElementAccessAnalysis
             return false;
 
         ExtensionMethodSymbolInfo reducedExtensionMethodInfo = semanticModel.GetReducedExtensionMethodInfo(invocationInfo.InvocationExpression, cancellationToken);
-        IMethodSymbol methodSymbol = reducedExtensionMethodInfo.Symbol;
+        IMethodSymbol? methodSymbol = reducedExtensionMethodInfo.Symbol;
 
         if (methodSymbol is null)
             return false;
@@ -100,9 +104,10 @@ internal static class UseElementAccessAnalysis
         if (!IsLinqExtensionOfIEnumerableOfTWithoutParameters(methodSymbol, "Last", allowImmutableArrayExtension: true))
             return false;
 
-        ITypeSymbol typeSymbol = semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken);
+        ITypeSymbol? typeSymbol = semanticModel.GetTypeSymbol(invocationInfo.Expression, cancellationToken);
 
-        return HasAccessibleIndexer(typeSymbol, reducedExtensionMethodInfo.ReducedSymbolOrSymbol.ReturnType, semanticModel, invocationInfo.InvocationExpression.SpanStart);
+        return typeSymbol is not null
+            && HasAccessibleIndexer(typeSymbol, reducedExtensionMethodInfo.ReducedSymbolOrSymbol.ReturnType, semanticModel, invocationInfo.InvocationExpression.SpanStart);
     }
 
     private static bool CheckInfiniteRecursion(
@@ -111,11 +116,11 @@ internal static class UseElementAccessAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        ISymbol symbol = semanticModel.GetEnclosingSymbol(position, cancellationToken);
+        ISymbol? symbol = semanticModel.GetEnclosingSymbol(position, cancellationToken);
 
         if (symbol is not null)
         {
-            IPropertySymbol propertySymbol = null;
+            IPropertySymbol? propertySymbol = null;
 
             if (symbol.Kind == SymbolKind.Property)
             {

--- a/src/Common/CSharp/Analysis/UseMethodChaining/MethodChainingWithAssignmentAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseMethodChaining/MethodChainingWithAssignmentAnalysis.cs
@@ -41,7 +41,7 @@ internal class MethodChainingWithAssignmentAnalysis : UseMethodChainingAnalysis
         if (name != identifierName.Identifier.ValueText)
             return false;
 
-        IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(invocationInfo.InvocationExpression, cancellationToken);
+        IMethodSymbol? methodSymbol = semanticModel.GetMethodSymbol(invocationInfo.InvocationExpression, cancellationToken);
 
         if (methodSymbol is null)
             return false;
@@ -62,7 +62,7 @@ internal class MethodChainingWithAssignmentAnalysis : UseMethodChainingAnalysis
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        ISymbol symbol = null;
+        ISymbol? symbol = null;
 
         foreach (SyntaxNode descendant in node.DescendantNodes())
         {

--- a/src/Common/CSharp/Analysis/UseMethodChaining/MethodChainingWithoutAssignmentAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseMethodChaining/MethodChainingWithoutAssignmentAnalysis.cs
@@ -35,7 +35,7 @@ internal class MethodChainingWithoutAssignmentAnalysis : UseMethodChainingAnalys
         if (name != identifierName.Identifier.ValueText)
             return false;
 
-        IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(topInvocationInfo.InvocationExpression, cancellationToken);
+        IMethodSymbol? methodSymbol = semanticModel.GetMethodSymbol(topInvocationInfo.InvocationExpression, cancellationToken);
 
         return methodSymbol?.IsStatic == false
             && SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, typeSymbol)

--- a/src/Common/CSharp/Analysis/UseMethodChaining/UseMethodChainingAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseMethodChaining/UseMethodChainingAnalysis.cs
@@ -21,7 +21,7 @@ internal abstract class UseMethodChainingAnalysis
     {
         InvocationExpressionSyntax invocationExpression = invocationInfo.InvocationExpression;
 
-        SyntaxNode parent = invocationExpression.Parent;
+        SyntaxNode? parent = invocationExpression.Parent;
 
         switch (parent?.Kind())
         {
@@ -84,7 +84,7 @@ internal abstract class UseMethodChainingAnalysis
         if (statements.Count == 1)
             return false;
 
-        IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(invocationInfo.InvocationExpression, cancellationToken);
+        IMethodSymbol? methodSymbol = semanticModel.GetMethodSymbol(invocationInfo.InvocationExpression, cancellationToken);
 
         if (methodSymbol is null)
             return false;

--- a/src/Common/CSharp/CodeStyle/BodyStyle.cs
+++ b/src/Common/CSharp/CodeStyle/BodyStyle.cs
@@ -32,7 +32,7 @@ internal readonly struct BodyStyle
 
         var option = BodyStyleOption.None;
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.BodyStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.BodyStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.BodyStyle_Block, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Common/CSharp/Extensions/CodeStyleExtensions.cs
+++ b/src/Common/CSharp/Extensions/CodeStyleExtensions.cs
@@ -12,7 +12,7 @@ internal static class CodeStyleExtensions
 {
     public static bool TryGetTabLength(this AnalyzerConfigOptions configOptions, out int tabLength)
     {
-        if (configOptions.TryGetValue(ConfigOptionKeys.TabLength, out string tabLengthStr)
+        if (configOptions.TryGetValue(ConfigOptionKeys.TabLength, out string? tabLengthStr)
             && int.TryParse(tabLengthStr, NumberStyles.None, CultureInfo.InvariantCulture, out tabLength))
         {
             return true;
@@ -24,7 +24,7 @@ internal static class CodeStyleExtensions
 
     public static bool TryGetIndentSize(this AnalyzerConfigOptions configOptions, out int indentSize)
     {
-        if (configOptions.TryGetValue("indent_size", out string indentSizeStr)
+        if (configOptions.TryGetValue("indent_size", out string? indentSizeStr)
             && int.TryParse(indentSizeStr, NumberStyles.None, CultureInfo.InvariantCulture, out indentSize))
         {
             return true;
@@ -36,7 +36,7 @@ internal static class CodeStyleExtensions
 
     public static bool TryGetIndentStyle(this AnalyzerConfigOptions configOptions, out IndentStyle indentStyle)
     {
-        if (configOptions.TryGetValue("indent_style", out string indentStyleStr)
+        if (configOptions.TryGetValue("indent_style", out string? indentStyleStr)
             && Enum.TryParse(indentStyleStr, ignoreCase: true, out indentStyle))
         {
             return true;
@@ -56,7 +56,7 @@ internal static class CodeStyleExtensions
 
     public static int GetMaxLineLength(this AnalyzerConfigOptions configOptions)
     {
-        if (configOptions.TryGetValue(ConfigOptionKeys.MaxLineLength, out string rawValue)
+        if (configOptions.TryGetValue(ConfigOptionKeys.MaxLineLength, out string? rawValue)
             && int.TryParse(rawValue, out int value))
         {
             return value;
@@ -133,7 +133,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.BlankLineBetweenUsingDirectives, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.BlankLineBetweenUsingDirectives, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.BlankLineBetweenUsingDirectives_Never, StringComparison.OrdinalIgnoreCase))
             {
@@ -152,7 +152,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.AccessorBracesStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.AccessorBracesStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.AccessorBracesStyle_MultiLine, StringComparison.OrdinalIgnoreCase))
             {
@@ -171,7 +171,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.BlockBracesStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.BlockBracesStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.BlockBracesStyle_MultiLine, StringComparison.OrdinalIgnoreCase))
             {
@@ -200,7 +200,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.UseAnonymousFunctionOrMethodGroup, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.UseAnonymousFunctionOrMethodGroup, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.UseAnonymousFunctionOrMethodGroup_AnonymousFunction, StringComparison.OrdinalIgnoreCase))
             {
@@ -219,7 +219,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.EnumHasFlagStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.EnumHasFlagStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.EnumHasFlagStyle_Method, StringComparison.OrdinalIgnoreCase))
             {
@@ -250,7 +250,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.EmptyStringStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.EmptyStringStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.EmptyStringStyle_Field, StringComparison.OrdinalIgnoreCase))
                 return EmptyStringStyle.Field;
@@ -266,7 +266,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.NullCheckStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.NullCheckStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.NullCheckStyle_EqualityOperator, StringComparison.OrdinalIgnoreCase))
                 return NullCheckStyle.EqualityOperator;
@@ -282,7 +282,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.ConditionalOperatorConditionParenthesesStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.ConditionalOperatorConditionParenthesesStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.ConditionalOperatorConditionParenthesesStyle_Include, StringComparison.OrdinalIgnoreCase))
             {
@@ -305,7 +305,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.ObjectCreationParenthesesStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.ObjectCreationParenthesesStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.ObjectCreationParenthesesStyle_Include, StringComparison.OrdinalIgnoreCase))
             {
@@ -324,7 +324,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.AccessibilityModifiers, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.AccessibilityModifiers, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.AccessibilityModifiers_Explicit, StringComparison.OrdinalIgnoreCase))
             {
@@ -343,7 +343,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.TrailingCommaStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.TrailingCommaStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.TrailingCommaStyle_Include, StringComparison.OrdinalIgnoreCase))
             {
@@ -366,7 +366,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.ObjectCreationTypeStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.ObjectCreationTypeStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.ObjectCreationTypeStyle_Implicit, StringComparison.OrdinalIgnoreCase))
             {
@@ -389,7 +389,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.UseVar, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.UseVar, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.UseVar_Always, StringComparison.OrdinalIgnoreCase))
             {
@@ -422,7 +422,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.ArrayCreationTypeStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.ArrayCreationTypeStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.ArrayCreationTypeStyle_Implicit, StringComparison.OrdinalIgnoreCase))
             {
@@ -448,7 +448,7 @@ internal static class CodeStyleExtensions
 
     public static InfiniteLoopStyle GetInfiniteLoopStyle(this AnalyzerConfigOptions configOptions)
     {
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.InfiniteLoopStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.InfiniteLoopStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.InfiniteLoopStyle_For, StringComparison.OrdinalIgnoreCase))
             {
@@ -467,7 +467,7 @@ internal static class CodeStyleExtensions
     {
         AnalyzerConfigOptions configOptions = context.GetConfigOptions();
 
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.DocCommentSummaryStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.DocCommentSummaryStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.DocCommentSummaryStyle_MultiLine, StringComparison.OrdinalIgnoreCase))
             {
@@ -489,7 +489,7 @@ internal static class CodeStyleExtensions
 
     public static EnumFlagValueStyle GetEnumFlagValueStyle(this AnalyzerConfigOptions configOptions)
     {
-        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.EnumFlagValueStyle, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, ConfigOptions.EnumFlagValueStyle, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.EnumFlagValueStyle_DecimalNumber, StringComparison.OrdinalIgnoreCase))
             {
@@ -539,7 +539,7 @@ internal static class CodeStyleExtensions
 
     public static BlankLineBetweenSwitchSections GetBlankLineBetweenSwitchSections(this SyntaxNodeAnalysisContext context)
     {
-        if (ConfigOptions.TryGetValue(context.GetConfigOptions(), ConfigOptions.BlankLineBetweenSwitchSections, out string rawValue))
+        if (ConfigOptions.TryGetValue(context.GetConfigOptions(), ConfigOptions.BlankLineBetweenSwitchSections, out string? rawValue))
         {
             if (string.Equals(rawValue, ConfigOptionValues.BlankLineBetweenSwitchSections_Include, StringComparison.OrdinalIgnoreCase))
                 return BlankLineBetweenSwitchSections.Include;
@@ -584,7 +584,7 @@ internal static class CodeStyleExtensions
         ConfigOptionDescriptor option,
         out NewLinePosition newLinePosition)
     {
-        if (ConfigOptions.TryGetValue(configOptions, option, out string rawValue))
+        if (ConfigOptions.TryGetValue(configOptions, option, out string? rawValue))
         {
             if (string.Equals(rawValue, "before", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Common/CSharp/IndentationAnalysis.cs
+++ b/src/Common/CSharp/IndentationAnalysis.cs
@@ -88,7 +88,7 @@ internal sealed class IndentationAnalysis
         }
         else
         {
-            return default;
+            return new IndentationAnalysis(indentation, null, null, null);
         }
     }
 
@@ -267,7 +267,10 @@ internal sealed class IndentationAnalysis
                 }
             }
 
-            node = node.Parent;
+            if (node.Parent is not { } parent)
+                break;
+
+            node = parent;
         }
         while (node is not null);
 
@@ -279,14 +282,14 @@ internal sealed class IndentationAnalysis
             {
                 if (member is NamespaceDeclarationSyntax namespaceDeclaration)
                 {
-                    MemberDeclarationSyntax member2 = namespaceDeclaration.Members.FirstOrDefault();
+                    MemberDeclarationSyntax? member2 = namespaceDeclaration.Members.FirstOrDefault();
 
                     if (member2 is not null)
                         return SyntaxTriviaAnalysis.DetermineIndentation(member2, cancellationToken);
                 }
                 else if (member is TypeDeclarationSyntax typeDeclaration)
                 {
-                    MemberDeclarationSyntax member2 = typeDeclaration.Members.FirstOrDefault();
+                    MemberDeclarationSyntax? member2 = typeDeclaration.Members.FirstOrDefault();
 
                     if (member2 is not null)
                         return SyntaxTriviaAnalysis.DetermineIndentation(member2, cancellationToken);
@@ -297,7 +300,7 @@ internal sealed class IndentationAnalysis
 
                     if (statement2 is SwitchStatementSyntax switchStatement)
                     {
-                        SwitchSectionSyntax switchSection = switchStatement.Sections.FirstOrDefault();
+                        SwitchSectionSyntax? switchSection = switchStatement.Sections.FirstOrDefault();
 
                         if (switchSection is not null)
                             return SyntaxTriviaAnalysis.DetermineIndentation(switchSection, cancellationToken);
@@ -306,7 +309,7 @@ internal sealed class IndentationAnalysis
                     }
                     else
                     {
-                        StatementSyntax statement3 = GetContainedStatement(statement2);
+                        StatementSyntax? statement3 = GetContainedStatement(statement2);
 
                         if (statement3 is not null)
                         {
@@ -344,7 +347,7 @@ internal sealed class IndentationAnalysis
             return default;
         }
 
-        StatementSyntax GetContainedStatement(StatementSyntax statement)
+        StatementSyntax? GetContainedStatement(StatementSyntax statement)
         {
             switch (statement.Kind())
             {

--- a/src/Common/CSharp/SyntaxTriviaAnalysis.cs
+++ b/src/Common/CSharp/SyntaxTriviaAnalysis.cs
@@ -140,8 +140,7 @@ internal static class SyntaxTriviaAnalysis
 
         SyntaxNode? node2 = node;
 
-        while (node2 is not null
-            && !node2.FullSpan.Contains(lineStartIndex))
+        while (node2?.FullSpan.Contains(lineStartIndex) == false)
             node2 = node2.GetParent(ascendOutOfTrivia: true);
 
         if (node2 is null)

--- a/src/Common/CSharp/SyntaxTriviaAnalysis.cs
+++ b/src/Common/CSharp/SyntaxTriviaAnalysis.cs
@@ -32,7 +32,7 @@ internal static class SyntaxTriviaAnalysis
     {
         if (nodeOrToken.IsNode)
         {
-            return DetermineEndOfLine(nodeOrToken.AsNode(), defaultValue);
+            return DetermineEndOfLine(nodeOrToken.AsNode()!, defaultValue);
         }
         else if (nodeOrToken.IsToken)
         {
@@ -112,7 +112,7 @@ internal static class SyntaxTriviaAnalysis
 
     public static SyntaxTrivia DetermineIndentation(SyntaxNodeOrToken nodeOrToken, CancellationToken cancellationToken = default)
     {
-        SyntaxTree tree = nodeOrToken.SyntaxTree;
+        SyntaxTree? tree = nodeOrToken.SyntaxTree;
 
         if (tree is null)
             return CSharpFactory.EmptyWhitespace();
@@ -134,14 +134,18 @@ internal static class SyntaxTriviaAnalysis
             }
         }
 
-        SyntaxNode node = (nodeOrToken.IsNode)
+        SyntaxNode? node = (nodeOrToken.IsNode)
             ? nodeOrToken.AsNode()
             : nodeOrToken.AsToken().Parent;
 
-        SyntaxNode node2 = node;
+        SyntaxNode? node2 = node;
 
-        while (!node2.FullSpan.Contains(lineStartIndex))
+        while (node2 is not null
+            && !node2.FullSpan.Contains(lineStartIndex))
             node2 = node2.GetParent(ascendOutOfTrivia: true);
+
+        if (node2 is null)
+            return CSharpFactory.EmptyWhitespace();
 
         if (node2.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
         {
@@ -171,7 +175,8 @@ internal static class SyntaxTriviaAnalysis
             }
         }
 
-        if (!IsMemberDeclarationOrStatementOrAccessorDeclaration(node))
+        if (node is not null
+            && !IsMemberDeclarationOrStatementOrAccessorDeclaration(node))
         {
             node = node.Parent;
 

--- a/src/Common/CSharp/TriviaBlock.cs
+++ b/src/Common/CSharp/TriviaBlock.cs
@@ -91,9 +91,12 @@ internal readonly struct TriviaBlock
             }
         }
 
-        return Location.Create(
-            (!First.IsKind(SyntaxKind.None)) ? First.SyntaxTree : Second.SyntaxTree,
-            span);
+        SyntaxTree? syntaxTree = (!First.IsKind(SyntaxKind.None)) ? First.SyntaxTree : Second.SyntaxTree;
+
+        if (syntaxTree is null)
+            return Location.None;
+
+        return Location.Create(syntaxTree, span);
     }
 
     public TriviaBlockReader CreateReader()

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -8,6 +8,7 @@
     <Version>$(RoslynatorVersion)</Version>
     <AssemblyName>$(RoslynatorDllPrefix)Roslynator.Common</AssemblyName>
     <RootNamespace>Roslynator</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Common/ConfigOptionDescriptor.cs
+++ b/src/Common/ConfigOptionDescriptor.cs
@@ -6,9 +6,9 @@ public class ConfigOptionDescriptor
 {
     public ConfigOptionDescriptor(
         string key,
-        string defaultValue = null,
-        string defaultValuePlaceholder = null,
-        string description = null)
+        string? defaultValue = null,
+        string? defaultValuePlaceholder = null,
+        string? description = null)
     {
         Key = key;
         DefaultValue = defaultValue;
@@ -21,11 +21,11 @@ public class ConfigOptionDescriptor
 
     public string Key { get; }
 
-    public string DefaultValue { get; }
+    public string? DefaultValue { get; }
 
     internal bool? DefaultValueAsBool { get; }
 
-    public string DefaultValuePlaceholder { get; }
+    public string? DefaultValuePlaceholder { get; }
 
-    public string Description { get; }
+    public string? Description { get; }
 }

--- a/src/Common/ConfigOptions.cs
+++ b/src/Common/ConfigOptions.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslynator.Configuration;
@@ -12,7 +13,7 @@ public static partial class ConfigOptions
 {
     private static readonly ImmutableDictionary<string, string> _requiredOptions = GetRequiredOptions().ToImmutableDictionary(f => f.Key, f => f.Value);
 
-    public static string GetRequiredOptions(DiagnosticDescriptor descriptor)
+    public static string? GetRequiredOptions(DiagnosticDescriptor descriptor)
     {
         Debug.Assert(_requiredOptions.ContainsKey(descriptor.Id), descriptor.Id);
 
@@ -24,9 +25,13 @@ public static partial class ConfigOptions
         return string.Join(" or ", values);
     }
 
-    public static bool TryGetValue(AnalyzerConfigOptions configOptions, ConfigOptionDescriptor option, out string value, string defaultValue = null)
+    public static bool TryGetValue(
+        AnalyzerConfigOptions configOptions,
+        ConfigOptionDescriptor option,
+        [NotNullWhen(true)] out string? value,
+        string? defaultValue = null)
     {
-        if (configOptions.TryGetValue(option.Key, out string rawValue))
+        if (configOptions.TryGetValue(option.Key, out string? rawValue))
         {
             value = rawValue;
             return true;
@@ -39,9 +44,9 @@ public static partial class ConfigOptions
         return value is not null;
     }
 
-    public static string GetValue(AnalyzerConfigOptions configOptions, ConfigOptionDescriptor option, string defaultValue = null)
+    public static string? GetValue(AnalyzerConfigOptions configOptions, ConfigOptionDescriptor option, string? defaultValue = null)
     {
-        if (configOptions.TryGetValue(option.Key, out string value))
+        if (configOptions.TryGetValue(option.Key, out string? value))
             return value;
 
         return defaultValue
@@ -51,7 +56,7 @@ public static partial class ConfigOptions
 
     public static bool TryGetValueAsBool(AnalyzerConfigOptions configOptions, ConfigOptionDescriptor option, out bool value, bool? defaultValue = null)
     {
-        if (configOptions.TryGetValue(option.Key, out string rawValue)
+        if (configOptions.TryGetValue(option.Key, out string? rawValue)
             && bool.TryParse(rawValue, out bool boolValue))
         {
             value = boolValue;
@@ -74,7 +79,7 @@ public static partial class ConfigOptions
 
     public static bool? GetValueAsBool(AnalyzerConfigOptions configOptions, ConfigOptionDescriptor option, bool? defaultValue = null)
     {
-        if (configOptions.TryGetValue(option.Key, out string rawValue)
+        if (configOptions.TryGetValue(option.Key, out string? rawValue)
             && bool.TryParse(rawValue, out bool boolValue))
         {
             return boolValue;

--- a/src/Common/Configuration/CodeAnalysisConfig.cs
+++ b/src/Common/Configuration/CodeAnalysisConfig.cs
@@ -16,9 +16,9 @@ public sealed class CodeAnalysisConfig
     public static CodeAnalysisConfig Instance { get; private set; } = new();
 
     private CodeAnalysisConfig(
-        XmlCodeAnalysisConfig xmlConfig = null,
-        EditorConfigCodeAnalysisConfig editorConfig = null,
-        VisualStudioCodeAnalysisConfig visualStudioConfig = null)
+        XmlCodeAnalysisConfig? xmlConfig = null,
+        EditorConfigCodeAnalysisConfig? editorConfig = null,
+        VisualStudioCodeAnalysisConfig? visualStudioConfig = null)
     {
         if (xmlConfig is not null)
         {
@@ -26,10 +26,10 @@ public sealed class CodeAnalysisConfig
         }
         else
         {
-            string xmlConfigPath = XmlCodeAnalysisConfig.GetDefaultConfigFilePath();
+            string? xmlConfigPath = XmlCodeAnalysisConfig.GetDefaultConfigFilePath();
 
-            XmlConfig = (File.Exists(xmlConfigPath))
-                ? XmlCodeAnalysisConfigLoader.Load(xmlConfigPath)
+            XmlConfig = (xmlConfigPath is not null && File.Exists(xmlConfigPath))
+                ? XmlCodeAnalysisConfigLoader.Load(xmlConfigPath) ?? XmlCodeAnalysisConfig.Empty
                 : XmlCodeAnalysisConfig.Empty;
         }
 
@@ -42,10 +42,10 @@ public sealed class CodeAnalysisConfig
             IEnumerable<string> editorConfigPaths = XmlConfig.Includes
                 .Where(path => Path.GetFileName(path) == EditorConfigCodeAnalysisConfig.FileName);
 
-            string defaultEditorConfigPath = EditorConfigCodeAnalysisConfig.GetDefaultConfigFilePath();
+            string? defaultEditorConfigPath = EditorConfigCodeAnalysisConfig.GetDefaultConfigFilePath();
 
             if (!string.IsNullOrEmpty(defaultEditorConfigPath))
-                editorConfigPaths = (new string[] { defaultEditorConfigPath }).Concat(editorConfigPaths);
+                editorConfigPaths = (new string[] { defaultEditorConfigPath! }).Concat(editorConfigPaths);
 
             EditorConfig = EditorConfigCodeAnalysisConfigLoader.Load(editorConfigPaths);
         }
@@ -127,7 +127,7 @@ public sealed class CodeAnalysisConfig
 
     public ImmutableDictionary<string, bool> CodeFixes { get; }
 
-    public static event EventHandler Updated;
+    public static event EventHandler? Updated;
 
     public bool? GetOptionAsBool(string key)
     {

--- a/src/Common/Configuration/ConfigMigrator.cs
+++ b/src/Common/Configuration/ConfigMigrator.cs
@@ -27,7 +27,12 @@ internal static class ConfigMigrator
 
     private static void Migrate(string path)
     {
-        string editorConfigPath = Path.Combine(Path.GetDirectoryName(path), EditorConfigCodeAnalysisConfig.FileName);
+        string? directoryPath = Path.GetDirectoryName(path);
+
+        if (string.IsNullOrEmpty(directoryPath))
+            return;
+
+        string editorConfigPath = Path.Combine(directoryPath, EditorConfigCodeAnalysisConfig.FileName);
 
         if (File.Exists(editorConfigPath))
             return;
@@ -35,39 +40,42 @@ internal static class ConfigMigrator
         var xmlConfigMigrated = false;
         var ruleSetMigrated = false;
 
-        EditorConfigWriter writer = null;
+        EditorConfigWriter? writer = null;
         try
         {
             if (File.Exists(path))
             {
-                XmlCodeAnalysisConfig config = XmlCodeAnalysisConfigLoader.Load(path, XmlConfigLoadOptions.SkipIncludes);
+                XmlCodeAnalysisConfig? config = XmlCodeAnalysisConfigLoader.Load(path, XmlConfigLoadOptions.SkipIncludes);
 
-                writer = new EditorConfigWriter(new StringWriter());
+                if (config is not null)
+                {
+                    writer = new EditorConfigWriter(new StringWriter());
 
-                writer.WriteGlobalDirective();
-                writer.WriteLine();
+                    writer.WriteGlobalDirective();
+                    writer.WriteLine();
 
-                if (config.MaxLineLength is not null)
-                    writer.WriteEntry(ConfigOptionKeys.MaxLineLength, config.MaxLineLength.ToString());
+                    if (config.MaxLineLength is not null)
+                        writer.WriteEntry(ConfigOptionKeys.MaxLineLength, config.MaxLineLength.ToString());
 
-                if (config.PrefixFieldIdentifierWithUnderscore is not null)
-                    writer.WriteEntry(ConfigOptionKeys.PrefixFieldIdentifierWithUnderscore, config.PrefixFieldIdentifierWithUnderscore.Value);
+                    if (config.PrefixFieldIdentifierWithUnderscore is not null)
+                        writer.WriteEntry(ConfigOptionKeys.PrefixFieldIdentifierWithUnderscore, config.PrefixFieldIdentifierWithUnderscore.Value);
 
-                writer.WriteLineIf(config.MaxLineLength is not null || config.PrefixFieldIdentifierWithUnderscore is not null);
+                    writer.WriteLineIf(config.MaxLineLength is not null || config.PrefixFieldIdentifierWithUnderscore is not null);
 
-                writer.WriteRefactorings(config.Refactorings.OrderBy(f => f.Key));
-                writer.WriteLineIf(config.Refactorings.Count > 0);
+                    writer.WriteRefactorings(config.Refactorings.OrderBy(f => f.Key));
+                    writer.WriteLineIf(config.Refactorings.Count > 0);
 
-                writer.WriteCompilerDiagnosticFixes(config.CodeFixes.OrderBy(f => f.Key));
-                writer.WriteLineIf(config.CodeFixes.Count > 0);
-                xmlConfigMigrated = true;
+                    writer.WriteCompilerDiagnosticFixes(config.CodeFixes.OrderBy(f => f.Key));
+                    writer.WriteLineIf(config.CodeFixes.Count > 0);
+                    xmlConfigMigrated = true;
+                }
             }
 
-            string ruleSetPath = Path.Combine(Path.GetDirectoryName(path), RuleSetLoader.DefaultRuleSetName);
+            string ruleSetPath = Path.Combine(directoryPath, RuleSetLoader.DefaultRuleSetName);
 
             if (File.Exists(ruleSetPath))
             {
-                RuleSet ruleSet = null;
+                RuleSet? ruleSet = null;
 
                 try
                 {

--- a/src/Common/Configuration/EditorConfigCodeAnalysisConfig.cs
+++ b/src/Common/Configuration/EditorConfigCodeAnalysisConfig.cs
@@ -49,11 +49,11 @@ roslynator_analyzers.enabled_by_default = true|false
     internal static EditorConfigCodeAnalysisConfig Empty { get; } = new();
 
     public EditorConfigCodeAnalysisConfig(
-        IEnumerable<KeyValuePair<string, string>> options = null,
-        IEnumerable<KeyValuePair<string, ReportDiagnostic>> analyzers = null,
-        IEnumerable<KeyValuePair<string, ReportDiagnostic>> analyzerCategories = null,
-        IEnumerable<KeyValuePair<string, bool>> refactorings = null,
-        IEnumerable<KeyValuePair<string, bool>> codeFixes = null,
+        IEnumerable<KeyValuePair<string, string>>? options = null,
+        IEnumerable<KeyValuePair<string, ReportDiagnostic>>? analyzers = null,
+        IEnumerable<KeyValuePair<string, ReportDiagnostic>>? analyzerCategories = null,
+        IEnumerable<KeyValuePair<string, bool>>? refactorings = null,
+        IEnumerable<KeyValuePair<string, bool>>? codeFixes = null,
         bool? analyzersEnabledByDefault = null)
     {
         Options = options?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty;
@@ -62,13 +62,13 @@ roslynator_analyzers.enabled_by_default = true|false
         Refactorings = refactorings?.ToImmutableDictionary(StringComparer.InvariantCultureIgnoreCase) ?? ImmutableDictionary<string, bool>.Empty;
         CodeFixes = codeFixes?.ToImmutableDictionary(StringComparer.InvariantCultureIgnoreCase) ?? ImmutableDictionary<string, bool>.Empty;
 
-        if (Options.TryGetValue(ConfigOptionKeys.MaxLineLength, out string maxLineLengthRaw)
+        if (Options.TryGetValue(ConfigOptionKeys.MaxLineLength, out string? maxLineLengthRaw)
             && int.TryParse(maxLineLengthRaw, out int maxLineLength))
         {
             MaxLineLength = maxLineLength;
         }
 
-        if (Options.TryGetValue(ConfigOptionKeys.PrefixFieldIdentifierWithUnderscore, out string prefixFieldIdentifierWithUnderscoreRaw)
+        if (Options.TryGetValue(ConfigOptionKeys.PrefixFieldIdentifierWithUnderscore, out string? prefixFieldIdentifierWithUnderscoreRaw)
             && bool.TryParse(prefixFieldIdentifierWithUnderscoreRaw, out bool prefixFieldIdentifierWithUnderscore))
         {
             PrefixFieldIdentifierWithUnderscore = prefixFieldIdentifierWithUnderscore;
@@ -103,7 +103,7 @@ roslynator_analyzers.enabled_by_default = true|false
         return CodeFixes;
     }
 
-    public static string GetDefaultConfigFilePath()
+    public static string? GetDefaultConfigFilePath()
     {
         string path = typeof(EditorConfigCodeAnalysisConfig).Assembly.Location;
 
@@ -197,7 +197,7 @@ roslynator_analyzers.enabled_by_default = true|false
         {
             try
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
 
                 File.WriteAllText(path, FileDefaultContent, Encoding.UTF8);
             }

--- a/src/Common/Configuration/EditorConfigCodeAnalysisConfigLoader.cs
+++ b/src/Common/Configuration/EditorConfigCodeAnalysisConfigLoader.cs
@@ -20,7 +20,7 @@ internal static class EditorConfigCodeAnalysisConfigLoader
             ?? EditorConfigCodeAnalysisConfig.Empty;
     }
 
-    internal static EditorConfigCodeAnalysisConfig LoadAndCatchIfThrows(IEnumerable<string> paths, Action<Exception> exceptionHandler)
+    internal static EditorConfigCodeAnalysisConfig? LoadAndCatchIfThrows(IEnumerable<string> paths, Action<Exception> exceptionHandler)
     {
         try
         {
@@ -36,10 +36,10 @@ internal static class EditorConfigCodeAnalysisConfigLoader
 
     private static EditorConfigCodeAnalysisConfig LoadInternal(IEnumerable<string> paths)
     {
-        Dictionary<string, bool> refactorings = null;
-        Dictionary<string, bool> codeFixes = null;
-        Dictionary<string, ReportDiagnostic> categories = null;
-        Dictionary<string, string> options = null;
+        Dictionary<string, bool>? refactorings = null;
+        Dictionary<string, bool>? codeFixes = null;
+        Dictionary<string, ReportDiagnostic>? categories = null;
+        Dictionary<string, string>? options = null;
         bool? analyzersEnabledByDefault = null;
 
         ImmutableDictionary<string, string> allOptions = ImmutableDictionary<string, string>.Empty;

--- a/src/Common/Configuration/EditorConfigWriter.cs
+++ b/src/Common/Configuration/EditorConfigWriter.cs
@@ -24,7 +24,7 @@ internal class EditorConfigWriter : IDisposable
         WriteEntry("is_global", true);
     }
 
-    public void WriteEntries(IEnumerable<KeyValuePair<string, string>> entries, string keyPrefix = null)
+    public void WriteEntries(IEnumerable<KeyValuePair<string, string>> entries, string? keyPrefix = null)
     {
         foreach (KeyValuePair<string, string> entry in entries)
         {

--- a/src/Common/Configuration/VisualStudioCodeAnalysisConfig.cs
+++ b/src/Common/Configuration/VisualStudioCodeAnalysisConfig.cs
@@ -11,8 +11,8 @@ internal class VisualStudioCodeAnalysisConfig
 
     public VisualStudioCodeAnalysisConfig(
         bool prefixFieldIdentifierWithUnderscore = ConfigOptionDefaultValues.PrefixFieldIdentifierWithUnderscore,
-        IEnumerable<KeyValuePair<string, bool>> refactorings = null,
-        IEnumerable<KeyValuePair<string, bool>> codeFixes = null)
+        IEnumerable<KeyValuePair<string, bool>>? refactorings = null,
+        IEnumerable<KeyValuePair<string, bool>>? codeFixes = null)
     {
         Refactorings = refactorings?.ToImmutableDictionary() ?? ImmutableDictionary<string, bool>.Empty;
         CodeFixes = codeFixes?.ToImmutableDictionary() ?? ImmutableDictionary<string, bool>.Empty;

--- a/src/Common/Configuration/XmlCodeAnalysisConfig.cs
+++ b/src/Common/Configuration/XmlCodeAnalysisConfig.cs
@@ -17,11 +17,11 @@ public class XmlCodeAnalysisConfig
     public static XmlCodeAnalysisConfig Empty { get; } = new();
 
     internal XmlCodeAnalysisConfig(
-        IEnumerable<string> includes = null,
-        IEnumerable<KeyValuePair<string, bool>> analyzers = null,
-        IEnumerable<KeyValuePair<string, bool>> codeFixes = null,
-        IEnumerable<KeyValuePair<string, bool>> refactorings = null,
-        IEnumerable<string> ruleSets = null,
+        IEnumerable<string>? includes = null,
+        IEnumerable<KeyValuePair<string, bool>>? analyzers = null,
+        IEnumerable<KeyValuePair<string, bool>>? codeFixes = null,
+        IEnumerable<KeyValuePair<string, bool>>? refactorings = null,
+        IEnumerable<string>? ruleSets = null,
         bool? prefixFieldIdentifierWithUnderscore = ConfigOptionDefaultValues.PrefixFieldIdentifierWithUnderscore,
         int? maxLineLength = ConfigOptionDefaultValues.MaxLineLength)
     {
@@ -36,7 +36,7 @@ public class XmlCodeAnalysisConfig
         string path = typeof(XmlCodeAnalysisConfig).Assembly.Location;
 
         if (!string.IsNullOrEmpty(path))
-            path = Path.Combine(Path.GetDirectoryName(path), RuleSetLoader.DefaultRuleSetName);
+            path = Path.Combine(Path.GetDirectoryName(path)!, RuleSetLoader.DefaultRuleSetName);
 
         RuleSet ruleSet = RuleSetLoader.Load(path, RuleSets) ?? RuleSetLoader.EmptyRuleSet;
 
@@ -62,7 +62,7 @@ public class XmlCodeAnalysisConfig
 
     public int? MaxLineLength { get; }
 
-    public static string GetDefaultConfigFilePath()
+    public static string? GetDefaultConfigFilePath()
     {
         string path = typeof(XmlCodeAnalysisConfig).Assembly.Location;
 

--- a/src/Common/Configuration/XmlCodeAnalysisConfigLoader.cs
+++ b/src/Common/Configuration/XmlCodeAnalysisConfigLoader.cs
@@ -361,7 +361,7 @@ internal static class XmlCodeAnalysisConfigLoader
             path = path.Replace("%LOCALAPPDATA%", localAppDataPath);
         }
 
-        return TryGetNormalizedFullPath(path, basePath, out string? result)
+        return (TryGetNormalizedFullPath(path, basePath, out string? result))
             ? result
             : null;
     }

--- a/src/Common/Configuration/XmlCodeAnalysisConfigLoader.cs
+++ b/src/Common/Configuration/XmlCodeAnalysisConfigLoader.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml;
 using System.Xml.Linq;
@@ -12,12 +13,12 @@ namespace Roslynator.Configuration;
 
 internal static class XmlCodeAnalysisConfigLoader
 {
-    public static XmlCodeAnalysisConfig Load(string path)
+    public static XmlCodeAnalysisConfig? Load(string path)
     {
         return LoadAndCatchIfThrows(path, exceptionHandler: ex => Debug.Fail(ex.ToString()));
     }
 
-    internal static XmlCodeAnalysisConfig LoadAndCatchIfThrows(string uri, XmlConfigLoadOptions options = XmlConfigLoadOptions.None, Action<Exception> exceptionHandler = null)
+    internal static XmlCodeAnalysisConfig? LoadAndCatchIfThrows(string uri, XmlConfigLoadOptions options = XmlConfigLoadOptions.None, Action<Exception>? exceptionHandler = null)
     {
         try
         {
@@ -32,14 +33,16 @@ internal static class XmlCodeAnalysisConfigLoader
         }
     }
 
-    internal static XmlCodeAnalysisConfig Load(string path, XmlConfigLoadOptions options = XmlConfigLoadOptions.None)
+    internal static XmlCodeAnalysisConfig? Load(string path, XmlConfigLoadOptions options = XmlConfigLoadOptions.None)
     {
-        if (!TryGetNormalizedFullPath(path, out path))
+        if (!TryGetNormalizedFullPath(path, out string? normalizedPath))
             return null;
 
-        Builder builder = null;
+        path = normalizedPath;
 
-        Queue<string> queue = null;
+        Builder? builder = null;
+
+        Queue<string>? queue = null;
 
         Load(path, ref builder, ref queue);
 
@@ -72,7 +75,7 @@ internal static class XmlCodeAnalysisConfigLoader
 
                 loadedIncludes.Add(include);
             }
-            while (queue.Count > 0);
+            while (queue!.Count > 0);
         }
 
         if (builder is null)
@@ -90,12 +93,12 @@ internal static class XmlCodeAnalysisConfigLoader
 
     private static void Load(
         string uri,
-        ref Builder builder,
-        ref Queue<string> includes)
+        ref Builder? builder,
+        ref Queue<string>? includes)
     {
         XDocument doc = XDocument.Load(uri);
 
-        string directoryPath = null;
+        string? directoryPath = null;
 
         XElement root = doc.Root;
 
@@ -120,7 +123,7 @@ internal static class XmlCodeAnalysisConfigLoader
                         {
                             directoryPath ??= Path.GetDirectoryName(uri);
 
-                            string path = LoadPath(attribute, directoryPath);
+                            string? path = LoadPath(attribute, directoryPath);
 
                             if (path is not null)
                                 (includes ??= new Queue<string>()).Enqueue(path);
@@ -241,7 +244,7 @@ internal static class XmlCodeAnalysisConfigLoader
         {
             if (e.HasName("Refactoring"))
             {
-                string id = null;
+                string? id = null;
                 bool? isEnabled = null;
 
                 foreach (XAttribute attribute in e.Attributes())
@@ -263,7 +266,7 @@ internal static class XmlCodeAnalysisConfigLoader
                 if (!string.IsNullOrEmpty(id)
                     && isEnabled is not null)
                 {
-                    builder.Refactorings[id] = isEnabled.Value;
+                    builder.Refactorings[id!] = isEnabled.Value;
                 }
             }
             else
@@ -279,7 +282,7 @@ internal static class XmlCodeAnalysisConfigLoader
         {
             if (e.HasName("CodeFix"))
             {
-                string id = null;
+                string? id = null;
                 bool? isEnabled = null;
 
                 foreach (XAttribute attribute in e.Attributes())
@@ -301,7 +304,7 @@ internal static class XmlCodeAnalysisConfigLoader
                 if (!string.IsNullOrEmpty(id)
                     && isEnabled is not null)
                 {
-                    builder.CodeFixes[id] = isEnabled.Value;
+                    builder.CodeFixes[id!] = isEnabled.Value;
                 }
             }
             else
@@ -313,13 +316,13 @@ internal static class XmlCodeAnalysisConfigLoader
 
     private static void LoadRuleSets(XElement element, Builder builder, string filePath)
     {
-        string directoryPath = null;
+        string? directoryPath = null;
 
         foreach (XElement e in element.Elements())
         {
             if (e.HasName("RuleSet"))
             {
-                string path = null;
+                string? path = null;
 
                 foreach (XAttribute attribute in e.Attributes())
                 {
@@ -337,7 +340,7 @@ internal static class XmlCodeAnalysisConfigLoader
 
                 if (!string.IsNullOrEmpty(path))
                 {
-                    builder.RuleSets.Add(path);
+                    builder.RuleSets.Add(path!);
                 }
             }
             else
@@ -347,7 +350,7 @@ internal static class XmlCodeAnalysisConfigLoader
         }
     }
 
-    private static string LoadPath(XAttribute attribute, string basePath)
+    private static string? LoadPath(XAttribute attribute, string? basePath)
     {
         string path = attribute.Value.Trim();
 
@@ -358,17 +361,17 @@ internal static class XmlCodeAnalysisConfigLoader
             path = path.Replace("%LOCALAPPDATA%", localAppDataPath);
         }
 
-        return (TryGetNormalizedFullPath(path, basePath, out path))
-            ? path
+        return TryGetNormalizedFullPath(path, basePath, out string? result)
+            ? result
             : null;
     }
 
     private class Builder
     {
-        private ImmutableDictionary<string, bool>.Builder _analyzers;
-        private ImmutableDictionary<string, bool>.Builder _codeFixes;
-        private ImmutableDictionary<string, bool>.Builder _refactorings;
-        private ImmutableArray<string>.Builder _ruleSets;
+        private ImmutableDictionary<string, bool>.Builder? _analyzers;
+        private ImmutableDictionary<string, bool>.Builder? _codeFixes;
+        private ImmutableDictionary<string, bool>.Builder? _refactorings;
+        private ImmutableArray<string>.Builder? _ruleSets;
 
         public ImmutableDictionary<string, bool>.Builder Analyzers
         {
@@ -395,14 +398,15 @@ internal static class XmlCodeAnalysisConfigLoader
         public int MaxLineLength { get; set; } = ConfigOptionDefaultValues.MaxLineLength;
     }
 
-    private static bool TryGetNormalizedFullPath(string path, out string result)
+    private static bool TryGetNormalizedFullPath(string path, [NotNullWhen(true)] out string? result)
     {
         return TryGetNormalizedFullPath(path, null, out result);
     }
 
-    private static bool TryGetNormalizedFullPath(string path, string basePath, out string result)
+    private static bool TryGetNormalizedFullPath(string path, string? basePath, [NotNullWhen(true)] out string? result)
     {
-        if (!FileSystemHelpers.TryGetNormalizedFullPath(path, basePath, out result))
+        if (!FileSystemHelpers.TryGetNormalizedFullPath(path, basePath, out result)
+            || result is null)
         {
             Debug.WriteLine($"Path is invalid: {path}");
             return false;

--- a/src/Common/DiagnosticDescriptorFactory.cs
+++ b/src/Common/DiagnosticDescriptorFactory.cs
@@ -14,8 +14,8 @@ internal static class DiagnosticDescriptorFactory
         string category,
         DiagnosticSeverity defaultSeverity,
         bool isEnabledByDefault,
-        string description = null,
-        string helpLinkUri = null,
+        string? description = null,
+        string? helpLinkUri = null,
         params string[] customTags)
     {
         isEnabledByDefault = CodeAnalysisConfig.Instance.IsDiagnosticEnabledByDefault(id, category, isEnabledByDefault);
@@ -28,7 +28,7 @@ internal static class DiagnosticDescriptorFactory
             defaultSeverity: CodeAnalysisConfig.Instance.GetDiagnosticSeverity(id, category, isEnabledByDefault) ?? defaultSeverity,
             isEnabledByDefault: isEnabledByDefault,
             description: description,
-            helpLinkUri: DiagnosticDescriptorUtility.GetHelpLinkUri(helpLinkUri),
+            helpLinkUri: DiagnosticDescriptorUtility.GetHelpLinkUri(helpLinkUri!),
             customTags: customTags);
     }
 

--- a/src/Common/DiagnosticHelpers.cs
+++ b/src/Common/DiagnosticHelpers.cs
@@ -424,7 +424,7 @@ internal static class DiagnosticHelpers
     [Conditional("DEBUG")]
     private static void VerifyMessageArgs(DiagnosticDescriptor descriptor, object?[]? messageArgs)
     {
-        messageArgs ??= [];
+        messageArgs ??= Array.Empty<object?>();
 
         string message = descriptor.MessageFormat.ToString();
         int count = Regex.Matches(message, @"\{\d\}").Count;

--- a/src/Common/DiagnosticHelpers.cs
+++ b/src/Common/DiagnosticHelpers.cs
@@ -17,7 +17,7 @@ internal static class DiagnosticHelpers
         SymbolAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxNode node,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -30,7 +30,7 @@ internal static class DiagnosticHelpers
         SymbolAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxToken token,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -43,7 +43,7 @@ internal static class DiagnosticHelpers
         SymbolAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxTrivia trivia,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -56,7 +56,7 @@ internal static class DiagnosticHelpers
         SymbolAnalysisContext context,
         DiagnosticDescriptor descriptor,
         Location location,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -68,7 +68,7 @@ internal static class DiagnosticHelpers
         DiagnosticDescriptor descriptor,
         Location location,
         IEnumerable<Location> additionalLocations,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -79,8 +79,8 @@ internal static class DiagnosticHelpers
         SymbolAnalysisContext context,
         DiagnosticDescriptor descriptor,
         Location location,
-        ImmutableDictionary<string, string> properties,
-        params object[] messageArgs)
+        ImmutableDictionary<string, string?> properties,
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -92,8 +92,8 @@ internal static class DiagnosticHelpers
         DiagnosticDescriptor descriptor,
         Location location,
         IEnumerable<Location> additionalLocations,
-        ImmutableDictionary<string, string> properties,
-        params object[] messageArgs)
+        ImmutableDictionary<string, string?> properties,
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -113,7 +113,7 @@ internal static class DiagnosticHelpers
         SyntaxNodeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxNode node,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         if (descriptor.IsEffective(context))
             ReportDiagnostic(context, descriptor, node, messageArgs);
@@ -123,7 +123,7 @@ internal static class DiagnosticHelpers
         SyntaxNodeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         Location location,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         if (descriptor.IsEffective(context))
             ReportDiagnostic(context, descriptor, location, messageArgs);
@@ -133,7 +133,7 @@ internal static class DiagnosticHelpers
         SyntaxNodeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxNode node,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -146,7 +146,7 @@ internal static class DiagnosticHelpers
         SyntaxNodeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxToken token,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -159,7 +159,7 @@ internal static class DiagnosticHelpers
         SyntaxNodeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxTrivia trivia,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -172,7 +172,7 @@ internal static class DiagnosticHelpers
         SyntaxNodeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         Location location,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -184,7 +184,7 @@ internal static class DiagnosticHelpers
         DiagnosticDescriptor descriptor,
         Location location,
         IEnumerable<Location> additionalLocations,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -195,8 +195,8 @@ internal static class DiagnosticHelpers
         SyntaxNodeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         Location location,
-        ImmutableDictionary<string, string> properties,
-        params object[] messageArgs)
+        ImmutableDictionary<string, string?> properties,
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -208,21 +208,21 @@ internal static class DiagnosticHelpers
         DiagnosticDescriptor descriptor,
         Location location,
         IEnumerable<Location> additionalLocations,
-        ImmutableDictionary<string, string> properties,
-        params object[] messageArgs)
+        ImmutableDictionary<string, string?> properties,
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
             CreateDiagnostic(descriptor, location, additionalLocations, properties, messageArgs));
     }
 
-    public static void ReportToken(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxToken token, params object[] messageArgs)
+    public static void ReportToken(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxToken token, params object?[]? messageArgs)
     {
         if (!token.IsMissing)
             ReportDiagnostic(context, descriptor, token, messageArgs);
     }
 
-    public static void ReportNode(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxNode node, params object[] messageArgs)
+    public static void ReportNode(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxNode node, params object?[]? messageArgs)
     {
         if (!node.IsMissing)
             ReportDiagnostic(context, descriptor, node, messageArgs);
@@ -241,7 +241,7 @@ internal static class DiagnosticHelpers
         SyntaxTreeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxNode node,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -254,7 +254,7 @@ internal static class DiagnosticHelpers
         SyntaxTreeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxToken token,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -267,7 +267,7 @@ internal static class DiagnosticHelpers
         SyntaxTreeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         SyntaxTrivia trivia,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context: context,
@@ -280,7 +280,7 @@ internal static class DiagnosticHelpers
         SyntaxTreeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         Location location,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -292,7 +292,7 @@ internal static class DiagnosticHelpers
         DiagnosticDescriptor descriptor,
         Location location,
         IEnumerable<Location> additionalLocations,
-        params object[] messageArgs)
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -303,8 +303,8 @@ internal static class DiagnosticHelpers
         SyntaxTreeAnalysisContext context,
         DiagnosticDescriptor descriptor,
         Location location,
-        ImmutableDictionary<string, string> properties,
-        params object[] messageArgs)
+        ImmutableDictionary<string, string?> properties,
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -316,8 +316,8 @@ internal static class DiagnosticHelpers
         DiagnosticDescriptor descriptor,
         Location location,
         IEnumerable<Location> additionalLocations,
-        ImmutableDictionary<string, string> properties,
-        params object[] messageArgs)
+        ImmutableDictionary<string, string?> properties,
+        params object?[]? messageArgs)
     {
         ReportDiagnostic(
             context,
@@ -377,7 +377,7 @@ internal static class DiagnosticHelpers
             || descriptor3.IsEffective(compilation);
     }
 
-    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location location, object[] messageArgs)
+    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location location, object?[]? messageArgs)
     {
         VerifyMessageArgs(descriptor, messageArgs);
 
@@ -387,7 +387,7 @@ internal static class DiagnosticHelpers
             messageArgs: messageArgs);
     }
 
-    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location location, IEnumerable<Location> additionalLocations, object[] messageArgs)
+    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location location, IEnumerable<Location> additionalLocations, object?[]? messageArgs)
     {
         VerifyMessageArgs(descriptor, messageArgs);
 
@@ -398,7 +398,7 @@ internal static class DiagnosticHelpers
             messageArgs: messageArgs);
     }
 
-    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location location, ImmutableDictionary<string, string> properties, object[] messageArgs)
+    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location location, ImmutableDictionary<string, string?> properties, object?[]? messageArgs)
     {
         VerifyMessageArgs(descriptor, messageArgs);
 
@@ -409,7 +409,7 @@ internal static class DiagnosticHelpers
             messageArgs: messageArgs);
     }
 
-    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location location, IEnumerable<Location> additionalLocations, ImmutableDictionary<string, string> properties, object[] messageArgs)
+    private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location location, IEnumerable<Location> additionalLocations, ImmutableDictionary<string, string?> properties, object?[]? messageArgs)
     {
         VerifyMessageArgs(descriptor, messageArgs);
 
@@ -422,8 +422,10 @@ internal static class DiagnosticHelpers
     }
 
     [Conditional("DEBUG")]
-    private static void VerifyMessageArgs(DiagnosticDescriptor descriptor, object[] messageArgs)
+    private static void VerifyMessageArgs(DiagnosticDescriptor descriptor, object?[]? messageArgs)
     {
+        messageArgs ??= [];
+
         string message = descriptor.MessageFormat.ToString();
         int count = Regex.Matches(message, @"\{\d\}").Count;
 

--- a/src/Common/DiagnosticProperties.cs
+++ b/src/Common/DiagnosticProperties.cs
@@ -8,15 +8,15 @@ namespace Roslynator;
 
 internal static class DiagnosticProperties
 {
-    public static ImmutableDictionary<string, string> NewLinePosition_After = ImmutableDictionary.CreateRange(new[] { new KeyValuePair<string, string>("NewLinePosition", "After") });
+    public static ImmutableDictionary<string, string?> NewLinePosition_After = ImmutableDictionary.CreateRange(new[] { new KeyValuePair<string, string?>("NewLinePosition", "After") });
 
-    private static ImmutableDictionary<string, string> _analyzerOption_Invert;
+    private static ImmutableDictionary<string, string?>? _analyzerOption_Invert;
 
     private const string AnalyzerOptionKey = "AnalyzerOption";
 
     private const string InvertValue = "Invert";
 
-    public static ImmutableDictionary<string, string> AnalyzerOption_Invert
+    public static ImmutableDictionary<string, string?> AnalyzerOption_Invert
     {
         get
         {
@@ -24,7 +24,7 @@ internal static class DiagnosticProperties
             {
                 Interlocked.CompareExchange(
                     ref _analyzerOption_Invert,
-                    ImmutableDictionary.CreateRange(new[] { new KeyValuePair<string, string>(AnalyzerOptionKey, InvertValue) }),
+                    ImmutableDictionary.CreateRange(new[] { new KeyValuePair<string, string?>(AnalyzerOptionKey, InvertValue) }),
                     null);
             }
 
@@ -32,9 +32,9 @@ internal static class DiagnosticProperties
         }
     }
 
-    public static bool ContainsInvert(ImmutableDictionary<string, string> properties)
+    public static bool ContainsInvert(ImmutableDictionary<string, string?> properties)
     {
-        return properties.TryGetValue(AnalyzerOptionKey, out string value)
+        return properties.TryGetValue(AnalyzerOptionKey, out string? value)
             && value == InvertValue;
     }
 }

--- a/src/Common/EquivalenceKey.cs
+++ b/src/Common/EquivalenceKey.cs
@@ -11,17 +11,17 @@ internal static class EquivalenceKey
 
     private const string Separator = ".";
 
-    public static string Create(RefactoringDescriptor descriptor, string additionalKey1 = null, string additionalKey2 = null)
+    public static string Create(RefactoringDescriptor descriptor, string? additionalKey1 = null, string? additionalKey2 = null)
     {
         return Create(descriptor.Id, additionalKey1, additionalKey2);
     }
 
-    public static string Create(Diagnostic diagnostic, string additionalKey1 = null, string additionalKey2 = null)
+    public static string Create(Diagnostic diagnostic, string? additionalKey1 = null, string? additionalKey2 = null)
     {
         return Create(diagnostic.Id, additionalKey1, additionalKey2);
     }
 
-    public static string Create(string key, string additionalKey1 = null, string additionalKey2 = null)
+    public static string Create(string key, string? additionalKey1 = null, string? additionalKey2 = null)
     {
         Debug.Assert(!string.IsNullOrEmpty(key));
 
@@ -46,7 +46,7 @@ internal static class EquivalenceKey
         }
     }
 
-    internal static string Join(string value1, string value2)
+    internal static string Join(string? value1, string? value2)
     {
         if (value1 is not null)
         {

--- a/src/Common/Extensions/CommonExtensions.cs
+++ b/src/Common/Extensions/CommonExtensions.cs
@@ -26,7 +26,7 @@ internal static class CommonExtensions
         if (analyzerOptions
             .AnalyzerConfigOptionsProvider
             .GetOptions(syntaxTree)
-            .TryGetValue(option.Key, out string value)
+            .TryGetValue(option.Key, out string? value)
             && bool.TryParse(value, out bool result))
         {
             return result;
@@ -55,7 +55,7 @@ internal static class CommonExtensions
         if (analyzerOptions
             .AnalyzerConfigOptionsProvider
             .GetOptions(syntaxTree)
-            .TryGetValue(option.Key, out string rawValue)
+            .TryGetValue(option.Key, out string? rawValue)
             && bool.TryParse(rawValue, out bool value))
         {
             result = value;
@@ -75,7 +75,7 @@ internal static class CommonExtensions
         if (analyzerOptions
             .AnalyzerConfigOptionsProvider
             .GetOptions(syntaxTree)
-            .TryGetValue(option.Key, out string rawValue)
+            .TryGetValue(option.Key, out string? rawValue)
             && int.TryParse(rawValue, NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite, CultureInfo.CurrentCulture, out int value))
         {
             result = value;
@@ -99,19 +99,19 @@ internal static class CommonExtensions
 
     internal static bool IsEnabled(this AnalyzerConfigOptions analyzerConfigOptions, ConfigOptionDescriptor option)
     {
-        return analyzerConfigOptions.TryGetValue(option.Key, out string rawValue)
+        return analyzerConfigOptions.TryGetValue(option.Key, out string? rawValue)
             && bool.TryParse(rawValue, out bool value)
             && value;
     }
 
     internal static bool ContainsKey(this AnalyzerConfigOptions analyzerConfigOptions, ConfigOptionDescriptor option)
     {
-        return analyzerConfigOptions.TryGetValue(option.Key, out string _);
+        return analyzerConfigOptions.TryGetValue(option.Key, out string? _);
     }
 
     internal static bool ContainsKey(this AnalyzerConfigOptions analyzerConfigOptions, string key)
     {
-        return analyzerConfigOptions.TryGetValue(key, out string _);
+        return analyzerConfigOptions.TryGetValue(key, out string? _);
     }
 
     internal static bool TryGetValueAsBool(this AnalyzerConfigOptions analyzerConfigOptions, ConfigOptionDescriptor option, out bool value)
@@ -123,7 +123,7 @@ internal static class CommonExtensions
     {
         value = false;
 
-        return analyzerConfigOptions.TryGetValue(key, out string rawValue)
+        return analyzerConfigOptions.TryGetValue(key, out string? rawValue)
             && bool.TryParse(rawValue, out value);
     }
 

--- a/src/Common/NullableAttributes.cs
+++ b/src/Common/NullableAttributes.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    public NotNullWhenAttribute(bool returnValue)
+    {
+        ReturnValue = returnValue;
+    }
+
+    public bool ReturnValue { get; }
+}

--- a/src/Common/RuleSetLoader.cs
+++ b/src/Common/RuleSetLoader.cs
@@ -11,7 +11,7 @@ namespace Roslynator;
 
 internal static class RuleSetLoader
 {
-    private static RuleSet _emptyRuleSet;
+    private static RuleSet? _emptyRuleSet;
 
     internal const string DefaultRuleSetName = "roslynator.ruleset";
 
@@ -35,13 +35,13 @@ internal static class RuleSetLoader
         }
     }
 
-    public static RuleSet Load(string path, ImmutableArray<string> additionalPaths)
+    public static RuleSet? Load(string path, ImmutableArray<string> additionalPaths)
     {
-        RuleSet ruleSet = Load(path);
+        RuleSet? ruleSet = Load(path);
 
         foreach (string ruleSetPath in additionalPaths)
         {
-            RuleSet ruleSet2 = Load(ruleSetPath);
+            RuleSet? ruleSet2 = Load(ruleSetPath);
 
             ruleSet = Combine(ruleSet, ruleSet2);
         }
@@ -49,12 +49,12 @@ internal static class RuleSetLoader
         return ruleSet;
     }
 
-    private static RuleSet Load(string path)
+    private static RuleSet? Load(string path)
     {
         if (!File.Exists(path))
             return null;
 
-        StreamWriter sw = null;
+        StreamWriter? sw = null;
         try
         {
             //sw = File.CreateText(path + ".log");
@@ -65,7 +65,7 @@ internal static class RuleSetLoader
 
             if (File.Exists(path))
             {
-                RuleSet ruleSet = null;
+                RuleSet? ruleSet = null;
 
                 try
                 {
@@ -105,7 +105,7 @@ internal static class RuleSetLoader
         return null;
     }
 
-    public static RuleSet Combine(RuleSet ruleSet, RuleSet parent)
+    public static RuleSet? Combine(RuleSet? ruleSet, RuleSet? parent)
     {
         if (ruleSet is null)
             return parent;

--- a/src/Workspaces.Common/CSharp/CodeActionFactory.cs
+++ b/src/Workspaces.Common/CSharp/CodeActionFactory.cs
@@ -23,7 +23,7 @@ internal static class CodeActionFactory
         Func<SyntaxToken, bool> tokenPredicate,
         string newLineReplacement = " ")
     {
-        SyntaxNode root = await context.GetSyntaxRootAsync().ConfigureAwait(false);
+        SyntaxNode root = (await context.GetSyntaxRootAsync().ConfigureAwait(false))!;
         Diagnostic diagnostic = context.Diagnostics[0];
         int position = context.Span.Start;
         SyntaxToken token = root.FindToken(position);
@@ -60,7 +60,7 @@ internal static class CodeActionFactory
 
         if (!block.ContainsComment)
         {
-            string indentation = null;
+            string? indentation = null;
 
             if (block.Kind == TriviaBlockKind.NoNewLine)
                 indentation = GetIncreasedIndentation(block.First, configOptions, context.CancellationToken);
@@ -91,7 +91,7 @@ internal static class CodeActionFactory
 
     public static async Task RegisterCodeActionForBlankLineAsync(CodeFixContext context)
     {
-        SyntaxNode root = await context.GetSyntaxRootAsync().ConfigureAwait(false);
+        SyntaxNode root = (await context.GetSyntaxRootAsync().ConfigureAwait(false))!;
         Diagnostic diagnostic = context.Diagnostics[0];
         int position = context.Span.Start;
 
@@ -100,7 +100,7 @@ internal static class CodeActionFactory
         TextChange textChange = GetTextChangeForBlankLine(block);
 
         CodeAction codeAction = CodeAction.Create(
-            (textChange.NewText.Length == 0) ? "Remove blank line" : "Add blank line",
+            (textChange.NewText?.Length == 0) ? "Remove blank line" : "Add blank line",
             ct => context.Document.WithTextChangeAsync(textChange, ct),
             EquivalenceKey.Create(diagnostic));
 
@@ -109,11 +109,11 @@ internal static class CodeActionFactory
 
     public static async Task RegisterCodeActionForNewLineAsync(
         CodeFixContext context,
-        string title = null,
-        string indentation = null,
+        string? title = null,
+        string? indentation = null,
         bool increaseIndentation = false)
     {
-        SyntaxNode root = await context.GetSyntaxRootAsync().ConfigureAwait(false);
+        SyntaxNode root = (await context.GetSyntaxRootAsync().ConfigureAwait(false))!;
         Diagnostic diagnostic = context.Diagnostics[0];
 
         TextChange textChange = GetTextChangeForNewLine(
@@ -125,7 +125,7 @@ internal static class CodeActionFactory
             context.CancellationToken);
 
         CodeAction codeAction = CodeAction.Create(
-            title ?? ((textChange.NewText.Length == 0) ? "Remove newline" : "Add newline"),
+            title ?? ((textChange.NewText?.Length == 0) ? "Remove newline" : "Add newline"),
             ct => context.Document.WithTextChangeAsync(textChange, ct),
             EquivalenceKey.Create(diagnostic));
 
@@ -136,7 +136,7 @@ internal static class CodeActionFactory
         SyntaxNode root,
         int position,
         AnalyzerConfigOptions configOptions,
-        string indentation = null,
+        string? indentation = null,
         bool increaseIndentation = false,
         CancellationToken cancellationToken = default)
     {
@@ -186,7 +186,7 @@ internal static class CodeActionFactory
     public static TextChange GetTextChangeForNewLine(
         TriviaBlock block,
         AnalyzerConfigOptions configOptions,
-        string indentation = null,
+        string? indentation = null,
         string newLineReplacement = " ",
         bool increaseIndentation = false,
         CancellationToken cancellationToken = default)
@@ -262,21 +262,21 @@ internal static class CodeActionFactory
 
     private static string GetIncreasedIndentation(SyntaxNodeOrToken nodeOrToken, AnalyzerConfigOptions configOptions, CancellationToken cancellationToken)
     {
-        SyntaxNode node = (nodeOrToken.IsNode) ? nodeOrToken.AsNode() : nodeOrToken.AsToken().Parent;
+        SyntaxNode? node = (nodeOrToken.IsNode) ? nodeOrToken.AsNode()! : nodeOrToken.AsToken().Parent;
 
-        SyntaxNode statementOrMember = node.FirstAncestorOrSelf(f => f is StatementSyntax
+        SyntaxNode? statementOrMember = node!.FirstAncestorOrSelf(f => f is StatementSyntax
             || f is MemberDeclarationSyntax
             || f is SwitchLabelSyntax);
 
-        return SyntaxTriviaAnalysis.GetIncreasedIndentation(statementOrMember ?? node, configOptions, cancellationToken);
+        return SyntaxTriviaAnalysis.GetIncreasedIndentation((statementOrMember ?? node)!, configOptions, cancellationToken);
     }
 
     public static CodeAction Create(
         string title,
         Func<CancellationToken, Task<Solution>> createChangedSolution,
         RefactoringDescriptor descriptor,
-        string additionalEquivalenceKey1 = null,
-        string additionalEquivalenceKey2 = null)
+        string? additionalEquivalenceKey1 = null,
+        string? additionalEquivalenceKey2 = null)
     {
         return CodeAction.Create(
             title,
@@ -288,8 +288,8 @@ internal static class CodeActionFactory
         string title,
         Func<CancellationToken, Task<Document>> createChangedDocument,
         RefactoringDescriptor descriptor,
-        string additionalEquivalenceKey1 = null,
-        string additionalEquivalenceKey2 = null)
+        string? additionalEquivalenceKey1 = null,
+        string? additionalEquivalenceKey2 = null)
     {
         return CodeAction.Create(
             title,
@@ -300,8 +300,8 @@ internal static class CodeActionFactory
     public static CodeAction ChangeTypeToVar(
         Document document,
         TypeSyntax type,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         return CodeAction.Create(
             title ?? "Use implicit type",
@@ -312,8 +312,8 @@ internal static class CodeActionFactory
     public static CodeAction ChangeTypeToVar(
         Document document,
         TupleExpressionSyntax tupleExpression,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         return CodeAction.Create(
             title ?? "Use implicit type",
@@ -326,7 +326,7 @@ internal static class CodeActionFactory
         TypeSyntax type,
         ITypeSymbol newTypeSymbol,
         SemanticModel semanticModel,
-        string equivalenceKey = null)
+        string? equivalenceKey = null)
     {
         return ChangeType(document, type, newTypeSymbol, semanticModel, title: "Use explicit type", equivalenceKey: equivalenceKey);
     }
@@ -336,8 +336,8 @@ internal static class CodeActionFactory
         TypeSyntax type,
         ITypeSymbol newTypeSymbol,
         SemanticModel semanticModel,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         if (title is null)
         {
@@ -383,8 +383,8 @@ internal static class CodeActionFactory
         ExpressionSyntax expression,
         ITypeSymbol destinationType,
         SemanticModel semanticModel,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         SymbolDisplayFormat format = GetSymbolDisplayFormat(expression, destinationType, semanticModel);
 
@@ -401,8 +401,8 @@ internal static class CodeActionFactory
     public static CodeAction RemoveMemberDeclaration(
         Document document,
         MemberDeclarationSyntax memberDeclaration,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         return CodeAction.Create(
             title ?? $"Remove {CSharpFacts.GetTitle(memberDeclaration)}",
@@ -413,8 +413,8 @@ internal static class CodeActionFactory
     public static CodeAction RemoveStatement(
         Document document,
         StatementSyntax statement,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         return CodeAction.Create(
             title ?? $"Remove {CSharpFacts.GetTitle(statement)}",
@@ -426,8 +426,8 @@ internal static class CodeActionFactory
         Document document,
         ExpressionSyntax expression,
         ITypeSymbol typeSymbol,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         return CodeAction.Create(
             title ?? "Replace 'null' with default value",
@@ -445,8 +445,8 @@ internal static class CodeActionFactory
     public static CodeAction RemoveAsyncAwait(
         Document document,
         SyntaxToken asyncKeyword,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         return CodeAction.Create(
             title ?? "Remove async/await",
@@ -457,8 +457,8 @@ internal static class CodeActionFactory
     public static CodeAction RemoveParentheses(
         Document document,
         ParenthesizedExpressionSyntax parenthesizedExpression,
-        string title = null,
-        string equivalenceKey = null)
+        string? title = null,
+        string? equivalenceKey = null)
     {
         return CodeAction.Create(
             title ?? "Remove parentheses",

--- a/src/Workspaces.Common/CSharp/CodeFixes/ModifiersCodeFixRegistrator.cs
+++ b/src/Workspaces.Common/CSharp/CodeFixes/ModifiersCodeFixRegistrator.cs
@@ -22,9 +22,9 @@ internal static class ModifiersCodeFixRegistrator
         Diagnostic diagnostic,
         SyntaxNode node,
         SyntaxKind modifierKind,
-        string title = null,
-        string additionalKey = null,
-        IComparer<SyntaxKind> comparer = null)
+        string? title = null,
+        string? additionalKey = null,
+        IComparer<SyntaxKind>? comparer = null)
     {
         AddModifier(context, context.Document, diagnostic, node, modifierKind, title, additionalKey, comparer);
     }
@@ -35,9 +35,9 @@ internal static class ModifiersCodeFixRegistrator
         Diagnostic diagnostic,
         SyntaxNode node,
         SyntaxKind modifierKind,
-        string title = null,
-        string additionalKey = null,
-        IComparer<SyntaxKind> comparer = null)
+        string? title = null,
+        string? additionalKey = null,
+        IComparer<SyntaxKind>? comparer = null)
     {
         CodeAction codeAction = CodeAction.Create(
             title ?? GetAddModifierTitle(modifierKind, node),
@@ -51,7 +51,7 @@ internal static class ModifiersCodeFixRegistrator
         Document document,
         TNode node,
         SyntaxKind modifierKind,
-        IComparer<SyntaxKind> comparer = null,
+        IComparer<SyntaxKind>? comparer = null,
         CancellationToken cancellationToken = default) where TNode : SyntaxNode
     {
         TNode newNode = AddModifier(node, modifierKind, comparer);
@@ -62,7 +62,7 @@ internal static class ModifiersCodeFixRegistrator
     private static TNode AddModifier<TNode>(
         TNode node,
         SyntaxKind modifierKind,
-        IComparer<SyntaxKind> comparer = null) where TNode : SyntaxNode
+        IComparer<SyntaxKind>? comparer = null) where TNode : SyntaxNode
     {
         switch (modifierKind)
         {
@@ -100,9 +100,9 @@ internal static class ModifiersCodeFixRegistrator
         Diagnostic diagnostic,
         IEnumerable<TNode> nodes,
         SyntaxKind modifierKind,
-        string title = null,
-        string additionalKey = null,
-        IComparer<SyntaxKind> comparer = null) where TNode : SyntaxNode
+        string? title = null,
+        string? additionalKey = null,
+        IComparer<SyntaxKind>? comparer = null) where TNode : SyntaxNode
     {
         if (nodes is IList<TNode> list)
         {
@@ -135,8 +135,8 @@ internal static class ModifiersCodeFixRegistrator
         Diagnostic diagnostic,
         SyntaxNode node,
         SyntaxKind modifierKind,
-        string title = null,
-        string additionalKey = null)
+        string? title = null,
+        string? additionalKey = null)
     {
         Document document = context.Document;
 
@@ -153,8 +153,8 @@ internal static class ModifiersCodeFixRegistrator
         Diagnostic diagnostic,
         SyntaxNode node,
         SyntaxToken modifier,
-        string title = null,
-        string additionalKey = null)
+        string? title = null,
+        string? additionalKey = null)
     {
         SyntaxKind kind = modifier.Kind();
 
@@ -195,8 +195,8 @@ internal static class ModifiersCodeFixRegistrator
         Diagnostic diagnostic,
         IEnumerable<TNode> nodes,
         SyntaxKind modifierKind,
-        string title = null,
-        string additionalKey = null) where TNode : SyntaxNode
+        string? title = null,
+        string? additionalKey = null) where TNode : SyntaxNode
     {
         if (nodes is IList<TNode> list)
         {
@@ -229,7 +229,7 @@ internal static class ModifiersCodeFixRegistrator
         Diagnostic diagnostic,
         SyntaxNode node,
         Func<SyntaxToken, bool> predicate,
-        string additionalKey = null)
+        string? additionalKey = null)
     {
         SyntaxTokenList modifiers = SyntaxInfo.ModifierListInfo(node).Modifiers;
 
@@ -242,9 +242,9 @@ internal static class ModifiersCodeFixRegistrator
         SyntaxNode node,
         SyntaxTokenList modifiers,
         Func<SyntaxToken, bool> predicate,
-        string additionalKey = null)
+        string? additionalKey = null)
     {
-        List<int> indexes = null;
+        List<int>? indexes = null;
 
         for (int i = 0; i < modifiers.Count; i++)
         {
@@ -282,7 +282,7 @@ internal static class ModifiersCodeFixRegistrator
         CodeFixContext context,
         Diagnostic diagnostic,
         SyntaxNode node,
-        string additionalKey = null)
+        string? additionalKey = null)
     {
         SyntaxTokenList modifiers = SyntaxInfo.ModifierListInfo(node).Modifiers;
         SyntaxToken modifier = modifiers.SingleOrDefault(shouldThrow: false);
@@ -311,7 +311,7 @@ internal static class ModifiersCodeFixRegistrator
         CodeFixContext context,
         Diagnostic diagnostic,
         SyntaxNode node,
-        string additionalKey = null)
+        string? additionalKey = null)
     {
         var accessModifier = default(SyntaxToken);
 
@@ -356,9 +356,9 @@ internal static class ModifiersCodeFixRegistrator
         Diagnostic diagnostic,
         SyntaxNode node,
         SyntaxToken modifier,
-        string title = null,
-        string additionalKey = null,
-        IComparer<SyntaxKind> comparer = null)
+        string? title = null,
+        string? additionalKey = null,
+        IComparer<SyntaxKind>? comparer = null)
     {
         Document document = context.Document;
 
@@ -405,7 +405,7 @@ internal static class ModifiersCodeFixRegistrator
             diagnostic);
     }
 
-    private static string GetEquivalenceKey(Diagnostic diagnostic, string additionalKey)
+    private static string GetEquivalenceKey(Diagnostic diagnostic, string? additionalKey)
     {
         return EquivalenceKey.Create(diagnostic, additionalKey);
     }
@@ -438,7 +438,7 @@ internal static class ModifiersCodeFixRegistrator
             : $"Remove modifier '{GetText(modifierKind)}'";
     }
 
-    private static string GetRemoveModifiersTitle(IEnumerable<SyntaxToken> modifiers, Func<SyntaxToken, bool> predicate = null)
+    private static string GetRemoveModifiersTitle(IEnumerable<SyntaxToken> modifiers, Func<SyntaxToken, bool>? predicate = null)
     {
         if (predicate is not null)
             modifiers = modifiers.Where(predicate);

--- a/src/Workspaces.Common/CSharp/DocumentRefactoringFactory.cs
+++ b/src/Workspaces.Common/CSharp/DocumentRefactoringFactory.cs
@@ -11,7 +11,7 @@ namespace Roslynator.CSharp;
 
 internal static class DocumentRefactoringFactory
 {
-    public static Func<CancellationToken, Task<Document>> ChangeTypeAndAddAwait(
+    public static Func<CancellationToken, Task<Document>>? ChangeTypeAndAddAwait(
         Document document,
         VariableDeclarationSyntax variableDeclaration,
         VariableDeclaratorSyntax variableDeclarator,
@@ -28,12 +28,12 @@ internal static class DocumentRefactoringFactory
         if (!methodSymbol.MethodKind.Is(MethodKind.Ordinary, MethodKind.LocalFunction))
             return default;
 
-        SyntaxNode containingMethod = GetContainingMethod();
+        SyntaxNode? containingMethod = GetContainingMethod();
 
         if (containingMethod is null)
             return default;
 
-        SyntaxNode bodyOrExpressionBody = GetBodyOrExpressionBody();
+        SyntaxNode? bodyOrExpressionBody = GetBodyOrExpressionBody();
 
         if (bodyOrExpressionBody is null)
             return default;
@@ -54,7 +54,7 @@ internal static class DocumentRefactoringFactory
 
         return ct => DocumentRefactorings.ChangeTypeAndAddAwaitAsync(document, variableDeclaration, variableDeclarator, containingMethod, typeArgument, semanticModel, ct);
 
-        SyntaxNode GetContainingMethod()
+        SyntaxNode? GetContainingMethod()
         {
             foreach (SyntaxReference syntaxReference in methodSymbol.DeclaringSyntaxReferences)
             {
@@ -67,9 +67,9 @@ internal static class DocumentRefactoringFactory
             return null;
         }
 
-        SyntaxNode GetBodyOrExpressionBody()
+        SyntaxNode? GetBodyOrExpressionBody()
         {
-            switch (containingMethod.Kind())
+            switch (containingMethod!.Kind())
             {
                 case SyntaxKind.MethodDeclaration:
                     return ((MethodDeclarationSyntax)containingMethod).BodyOrExpressionBody();

--- a/src/Workspaces.Common/CSharp/DocumentRefactorings.cs
+++ b/src/Workspaces.Common/CSharp/DocumentRefactorings.cs
@@ -31,7 +31,7 @@ internal static class DocumentRefactorings
             && declarationExpression.Designation is ParenthesizedVariableDesignationSyntax designation)
         {
 #if DEBUG
-            SyntaxNode parent = declarationExpression.Parent;
+            SyntaxNode parent = declarationExpression.Parent!;
 
             switch (parent.Kind())
             {
@@ -242,7 +242,7 @@ internal static class DocumentRefactorings
     {
         TypeSyntax type = variableDeclaration.Type;
 
-        ExpressionSyntax value = variableDeclarator.Initializer.Value;
+        ExpressionSyntax value = variableDeclarator.Initializer!.Value;
 
         AwaitExpressionSyntax newValue = AwaitExpression(value.WithoutTrivia()).WithTriviaFrom(value);
 
@@ -302,15 +302,15 @@ internal static class DocumentRefactorings
 
     public static async Task<Document> AddNewDocumentationCommentsAsync(
         Document document,
-        DocumentationCommentGeneratorSettings settings = null,
+        DocumentationCommentGeneratorSettings? settings = null,
         bool skipNamespaceDeclaration = true,
         CancellationToken cancellationToken = default)
     {
-        SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        SyntaxNode root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))!;
 
         var rewriter = new AddNewDocumentationCommentRewriter(settings, skipNamespaceDeclaration);
 
-        SyntaxNode newRoot = rewriter.Visit(root);
+        SyntaxNode newRoot = rewriter.Visit(root)!;
 
         return document.WithSyntaxRoot(newRoot);
     }
@@ -318,15 +318,15 @@ internal static class DocumentRefactorings
     public static async Task<Document> AddBaseOrNewDocumentationCommentsAsync(
         Document document,
         SemanticModel semanticModel,
-        DocumentationCommentGeneratorSettings settings = null,
+        DocumentationCommentGeneratorSettings? settings = null,
         bool skipNamespaceDeclaration = true,
         CancellationToken cancellationToken = default)
     {
-        SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        SyntaxNode root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))!;
 
         var rewriter = new AddBaseOrNewDocumentationCommentRewriter(semanticModel, settings, skipNamespaceDeclaration, cancellationToken);
 
-        SyntaxNode newRoot = rewriter.Visit(root);
+        SyntaxNode newRoot = rewriter.Visit(root)!;
 
         return document.WithSyntaxRoot(newRoot);
     }
@@ -355,7 +355,7 @@ internal static class DocumentRefactorings
 
         if (!leading.Any())
         {
-            SyntaxNode parent = parenthesizedExpression.Parent;
+            SyntaxNode parent = parenthesizedExpression.Parent!;
 
             switch (parent.Kind())
             {

--- a/src/Workspaces.Common/CSharp/Refactorings/AddBracesToIfElseRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/AddBracesToIfElseRefactoring.cs
@@ -26,9 +26,9 @@ internal static class AddBracesToIfElseRefactoring
 
     private class SyntaxRewriter : CSharpSyntaxRewriter
     {
-        private IfStatementSyntax _previousIf;
+        private IfStatementSyntax? _previousIf;
 
-        public override SyntaxNode VisitIfStatement(IfStatementSyntax node)
+        public override SyntaxNode? VisitIfStatement(IfStatementSyntax node)
         {
             if (node is null)
                 throw new ArgumentNullException(nameof(node));
@@ -52,12 +52,12 @@ internal static class AddBracesToIfElseRefactoring
             return base.VisitIfStatement(node);
         }
 
-        public override SyntaxNode VisitElseClause(ElseClauseSyntax node)
+        public override SyntaxNode? VisitElseClause(ElseClauseSyntax node)
         {
             if (node is null)
                 throw new ArgumentNullException(nameof(node));
 
-            if (_previousIf.Equals(node.Parent)
+            if (_previousIf!.Equals(node.Parent)
                 && node.Statement?.IsKind(SyntaxKind.Block, SyntaxKind.IfStatement) == false)
             {
                 return node.WithStatement(SyntaxFactory.Block(node.Statement));

--- a/src/Workspaces.Common/CSharp/Refactorings/AddExceptionToDocumentationComment/AddExceptionElementToDocumentationCommentRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/AddExceptionToDocumentationComment/AddExceptionElementToDocumentationCommentRefactoring.cs
@@ -36,7 +36,7 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
                     {
                         var throwStatement = (ThrowStatementSyntax)node;
 
-                        ThrowInfo info = GetUndocumentedExceptionInfo(node, throwStatement.Expression, declaration, declarationSymbol, exceptionSymbol, semanticModel, cancellationToken);
+                        ThrowInfo? info = GetUndocumentedExceptionInfo(node, throwStatement.Expression, declaration, declarationSymbol, exceptionSymbol, semanticModel, cancellationToken);
 
                         if (info is not null)
                             yield return info;
@@ -49,7 +49,7 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
                     if (predicate(node))
                     {
                         var throwExpression = (ThrowExpressionSyntax)node;
-                        ThrowInfo info = GetUndocumentedExceptionInfo(node, throwExpression.Expression, declaration, declarationSymbol, exceptionSymbol, semanticModel, cancellationToken);
+                        ThrowInfo? info = GetUndocumentedExceptionInfo(node, throwExpression.Expression, declaration, declarationSymbol, exceptionSymbol, semanticModel, cancellationToken);
 
                         if (info is not null)
                             yield return info;
@@ -61,9 +61,9 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
         }
     }
 
-    private static ThrowInfo GetUndocumentedExceptionInfo(
+    private static ThrowInfo? GetUndocumentedExceptionInfo(
         SyntaxNode node,
-        ExpressionSyntax expression,
+        ExpressionSyntax? expression,
         MemberDeclarationSyntax declaration,
         ISymbol declarationSymbol,
         INamedTypeSymbol exceptionSymbol,
@@ -79,7 +79,7 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
         if (!InheritsFromException(typeSymbol, exceptionSymbol))
             return null;
 
-        DocumentationCommentTriviaSyntax comment = declaration.GetSingleLineDocumentationComment();
+        DocumentationCommentTriviaSyntax? comment = declaration.GetSingleLineDocumentationComment();
 
         if (comment is null)
             return null;
@@ -211,7 +211,7 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
         return RefactorAsync(document, throwStatement, throwStatement.Expression, cancellationToken);
     }
 
-    private static bool InheritsFromException(ITypeSymbol typeSymbol, INamedTypeSymbol exceptionSymbol)
+    private static bool InheritsFromException(ITypeSymbol? typeSymbol, INamedTypeSymbol exceptionSymbol)
     {
         return typeSymbol?.TypeKind == TypeKind.Class
             && typeSymbol.BaseType?.IsObject() == false
@@ -221,29 +221,29 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
     private static async Task<Document> RefactorAsync(
         Document document,
         SyntaxNode node,
-        ExpressionSyntax expression,
+        ExpressionSyntax? expression,
         CancellationToken cancellationToken)
     {
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
-        ITypeSymbol exceptionSymbol = semanticModel.GetTypeSymbol(expression, cancellationToken);
+        ITypeSymbol? exceptionSymbol = semanticModel.GetTypeSymbol(expression!, cancellationToken);
 
-        ISymbol declarationSymbol = AddExceptionToDocumentationCommentAnalysis.GetDeclarationSymbol(node.SpanStart, semanticModel, cancellationToken);
+        ISymbol? declarationSymbol = AddExceptionToDocumentationCommentAnalysis.GetDeclarationSymbol(node.SpanStart, semanticModel, cancellationToken);
 
-        var memberDeclaration = (MemberDeclarationSyntax)await declarationSymbol
+        var memberDeclaration = (MemberDeclarationSyntax)await declarationSymbol!
             .GetSyntaxAsync(cancellationToken)
             .ConfigureAwait(false);
 
         SyntaxTrivia trivia = memberDeclaration.GetSingleLineDocumentationCommentTrivia();
 
-        ThrowInfo throwInfo = ThrowInfo.Create(node, exceptionSymbol, declarationSymbol);
+        ThrowInfo throwInfo = ThrowInfo.Create(node, exceptionSymbol!, declarationSymbol!);
 
         return await RefactorAsync(
             document,
             trivia,
             throwInfo,
             memberDeclaration,
-            declarationSymbol,
+            declarationSymbol!,
             semanticModel,
             cancellationToken)
             .ConfigureAwait(false);
@@ -254,9 +254,9 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
         AddExceptionToDocumentationCommentAnalysisResult analysis,
         CancellationToken cancellationToken)
     {
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
-        var memberDeclaration = (MemberDeclarationSyntax)await analysis.DeclarationSymbol
+        var memberDeclaration = (MemberDeclarationSyntax)await analysis.DeclarationSymbol!
             .GetSyntaxAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -265,7 +265,7 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
             analysis.DocumentationComment,
             analysis.ThrowInfo,
             memberDeclaration,
-            analysis.DeclarationSymbol,
+            analysis.DeclarationSymbol!,
             semanticModel,
             cancellationToken)
             .ConfigureAwait(false);
@@ -282,9 +282,9 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
     {
         var throwInfos = new List<ThrowInfo>() { throwInfo };
 
-        INamedTypeSymbol exceptionSymbol = semanticModel.GetTypeByMetadataName("System.Exception");
+        INamedTypeSymbol? exceptionSymbol = semanticModel.GetTypeByMetadataName("System.Exception");
 
-        foreach (ThrowInfo info in GetOtherUndocumentedExceptions(memberDeclaration, declarationSymbol, node => node != throwInfo.Node, exceptionSymbol, semanticModel, cancellationToken))
+        foreach (ThrowInfo info in GetOtherUndocumentedExceptions(memberDeclaration, declarationSymbol, node => node != throwInfo.Node, exceptionSymbol!, semanticModel, cancellationToken))
         {
             if (!throwInfos.Any(f => SymbolEqualityComparer.Default.Equals(f.ExceptionSymbol, info.ExceptionSymbol)))
                 throwInfos.Add(info);
@@ -298,7 +298,7 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
         {
             sb.Append(indent);
 
-            IParameterSymbol parameterSymbol = info.GetParameterSymbol(semanticModel, cancellationToken);
+            IParameterSymbol? parameterSymbol = info.GetParameterSymbol(semanticModel, cancellationToken);
 
             AppendExceptionDocumentation(trivia, info.ExceptionSymbol, parameterSymbol, semanticModel, ref sb);
         }
@@ -330,7 +330,7 @@ internal static class AddExceptionElementToDocumentationCommentRefactoring
     private static void AppendExceptionDocumentation(
         SyntaxTrivia trivia,
         ITypeSymbol exceptionSymbol,
-        IParameterSymbol parameterSymbol,
+        IParameterSymbol? parameterSymbol,
         SemanticModel semanticModel,
         ref StringBuilder sb)
     {

--- a/src/Workspaces.Common/CSharp/Refactorings/AddParameterToInterfaceMemberRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/AddParameterToInterfaceMemberRefactoring.cs
@@ -15,7 +15,7 @@ namespace Roslynator.CSharp.Refactorings;
 
 internal static class AddParameterToInterfaceMemberRefactoring
 {
-    public static CodeAction ComputeRefactoringForExplicitImplementation(
+    public static CodeAction? ComputeRefactoringForExplicitImplementation(
         CommonFixContext context,
         MemberDeclarationSyntax memberDeclaration)
     {
@@ -70,7 +70,7 @@ internal static class AddParameterToInterfaceMemberRefactoring
         CommonFixContext context,
         MemberDeclarationSyntax memberDeclaration,
         SyntaxTokenList modifiers,
-        ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier,
+        ExplicitInterfaceSpecifierSyntax? explicitInterfaceSpecifier,
         SeparatedSyntaxList<ParameterSyntax> parameters)
     {
         if (!parameters.Any())
@@ -88,21 +88,21 @@ internal static class AddParameterToInterfaceMemberRefactoring
             modifiers);
     }
 
-    public static CodeAction ComputeRefactoringForExplicitImplementation(
+    public static CodeAction? ComputeRefactoringForExplicitImplementation(
         CommonFixContext context,
         MemberDeclarationSyntax memberDeclaration,
-        ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier,
+        ExplicitInterfaceSpecifierSyntax? explicitInterfaceSpecifier,
         SeparatedSyntaxList<ParameterSyntax> parameters)
     {
         if (!parameters.Any())
             return default;
 
-        NameSyntax explicitInterfaceName = explicitInterfaceSpecifier?.Name;
+        NameSyntax? explicitInterfaceName = explicitInterfaceSpecifier?.Name;
 
         if (explicitInterfaceName is null)
             return default;
 
-        var interfaceSymbol = (INamedTypeSymbol)context.SemanticModel.GetTypeSymbol(explicitInterfaceName, context.CancellationToken);
+        var interfaceSymbol = (INamedTypeSymbol?)context.SemanticModel.GetTypeSymbol(explicitInterfaceName, context.CancellationToken);
 
         if (interfaceSymbol?.TypeKind != TypeKind.Interface)
             return default;
@@ -110,12 +110,12 @@ internal static class AddParameterToInterfaceMemberRefactoring
         if (interfaceSymbol.GetSyntaxOrDefault(context.CancellationToken) is not InterfaceDeclarationSyntax _)
             return default;
 
-        ISymbol memberSymbol = context.SemanticModel.GetDeclaredSymbol(memberDeclaration, context.CancellationToken);
+        ISymbol? memberSymbol = context.SemanticModel.GetDeclaredSymbol(memberDeclaration, context.CancellationToken);
 
         if (memberSymbol is null)
             return default;
 
-        ISymbol interfaceMemberSymbol = FindInterfaceMember(memberSymbol, interfaceSymbol);
+        ISymbol? interfaceMemberSymbol = FindInterfaceMember(memberSymbol, interfaceSymbol);
 
         if (interfaceMemberSymbol is null)
             return default;
@@ -131,14 +131,14 @@ internal static class AddParameterToInterfaceMemberRefactoring
         if (!modifiers.Contains(SyntaxKind.PublicKeyword))
             return default;
 
-        BaseListSyntax baseList = GetBaseList(memberDeclaration.Parent);
+        BaseListSyntax? baseList = GetBaseList(memberDeclaration.Parent);
 
         if (baseList is null)
             return default;
 
         SeparatedSyntaxList<BaseTypeSyntax> baseTypes = baseList.Types;
 
-        ISymbol memberSymbol = context.SemanticModel.GetDeclaredSymbol(memberDeclaration, context.CancellationToken);
+        ISymbol? memberSymbol = context.SemanticModel.GetDeclaredSymbol(memberDeclaration, context.CancellationToken);
 
         if (memberSymbol is null)
             return default;
@@ -148,14 +148,14 @@ internal static class AddParameterToInterfaceMemberRefactoring
 
         int count = 0;
 
-        CodeAction singleCodeAction = null;
-        List<CodeAction> codeActions = default;
+        CodeAction? singleCodeAction = null;
+        List<CodeAction>? codeActions = default;
 
         for (int i = 0; i < baseTypes.Count; i++)
         {
             BaseTypeSyntax baseType = baseTypes[i];
 
-            Diagnostic diagnostic = context.SemanticModel.GetDiagnostic("CS0535", baseType.Type.Span, context.CancellationToken);
+            Diagnostic? diagnostic = context.SemanticModel.GetDiagnostic("CS0535", baseType.Type.Span, context.CancellationToken);
 
             if (diagnostic?.Location.SourceSpan != baseType.Type.Span)
                 continue;
@@ -168,7 +168,7 @@ internal static class AddParameterToInterfaceMemberRefactoring
             if (interfaceSymbol.GetSyntaxOrDefault(context.CancellationToken) is not InterfaceDeclarationSyntax _)
                 continue;
 
-            ISymbol interfaceMemberSymbol = FindInterfaceMember(memberSymbol, interfaceSymbol);
+            ISymbol? interfaceMemberSymbol = FindInterfaceMember(memberSymbol, interfaceSymbol);
 
             if (interfaceMemberSymbol is not null)
             {
@@ -202,7 +202,7 @@ internal static class AddParameterToInterfaceMemberRefactoring
         return default;
     }
 
-    private static ISymbol FindInterfaceMember(
+    private static ISymbol? FindInterfaceMember(
         ISymbol memberSymbol,
         INamedTypeSymbol interfaceSymbol)
     {
@@ -226,7 +226,7 @@ internal static class AddParameterToInterfaceMemberRefactoring
         return null;
     }
 
-    private static ISymbol FindInterfaceMethod(
+    private static ISymbol? FindInterfaceMethod(
         IMethodSymbol methodSymbol,
         INamedTypeSymbol interfaceSymbol)
     {
@@ -277,7 +277,7 @@ internal static class AddParameterToInterfaceMemberRefactoring
         return null;
     }
 
-    private static ISymbol FindInterfaceIndexer(
+    private static ISymbol? FindInterfaceIndexer(
         IPropertySymbol propertySymbol,
         INamedTypeSymbol interfaceSymbol)
     {
@@ -382,9 +382,9 @@ internal static class AddParameterToInterfaceMemberRefactoring
         }
     }
 
-    private static BaseListSyntax GetBaseList(SyntaxNode node)
+    private static BaseListSyntax? GetBaseList(SyntaxNode? node)
     {
-        switch (node.Kind())
+        switch (node?.Kind())
         {
             case SyntaxKind.ClassDeclaration:
                 return ((ClassDeclarationSyntax)node).BaseList;
@@ -399,7 +399,7 @@ internal static class AddParameterToInterfaceMemberRefactoring
 
     private static ParameterSyntax CreateParameter(IParameterSymbol parameterSymbol)
     {
-        ExpressionSyntax defaultValue = (parameterSymbol.HasExplicitDefaultValue)
+        ExpressionSyntax? defaultValue = (parameterSymbol.HasExplicitDefaultValue)
             ? parameterSymbol.GetDefaultValueSyntax()
             : null;
 

--- a/src/Workspaces.Common/CSharp/Refactorings/ChangeAccessibilityRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ChangeAccessibilityRefactoring.cs
@@ -22,9 +22,9 @@ internal static class ChangeAccessibilityRefactoring
         Accessibility.Protected,
         Accessibility.Private);
 
-    public static ISymbol GetBaseSymbolOrDefault(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
+    public static ISymbol? GetBaseSymbolOrDefault(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        ISymbol symbol = GetDeclaredSymbol();
+        ISymbol? symbol = GetDeclaredSymbol();
 
         if (symbol is not null)
         {
@@ -35,7 +35,7 @@ internal static class ChangeAccessibilityRefactoring
 
             if (symbol is not null)
             {
-                SyntaxNode syntax = symbol.GetSyntaxOrDefault(cancellationToken);
+                SyntaxNode? syntax = symbol.GetSyntaxOrDefault(cancellationToken);
 
                 if (syntax is not null)
                 {
@@ -50,11 +50,11 @@ internal static class ChangeAccessibilityRefactoring
 
         return null;
 
-        ISymbol GetDeclaredSymbol()
+        ISymbol? GetDeclaredSymbol()
         {
             if (node is EventFieldDeclarationSyntax eventFieldDeclaration)
             {
-                VariableDeclaratorSyntax declarator = eventFieldDeclaration.Declaration?.Variables.SingleOrDefault(shouldThrow: false);
+                VariableDeclaratorSyntax? declarator = eventFieldDeclaration.Declaration?.Variables.SingleOrDefault(shouldThrow: false);
 
                 if (declarator is not null)
                     return semanticModel.GetDeclaredSymbol(declarator, cancellationToken);
@@ -98,14 +98,14 @@ internal static class ChangeAccessibilityRefactoring
 
             if (filter.HasAnyFlag(ModifierFilter.Partial))
             {
-                ISymbol symbol = semanticModel.GetDeclaredSymbol(member, cancellationToken);
+                ISymbol? symbol = semanticModel.GetDeclaredSymbol(member, cancellationToken);
 
-                foreach (SyntaxReference reference in symbol.DeclaringSyntaxReferences)
+                foreach (SyntaxReference reference in symbol!.DeclaringSyntaxReferences)
                     members.Add((MemberDeclarationSyntax)reference.GetSyntax(cancellationToken));
             }
             else if (filter.HasAnyFlag(ModifierFilter.AbstractVirtualOverride))
             {
-                ISymbol symbol = GetBaseSymbolOrDefault(member, semanticModel, cancellationToken);
+                ISymbol? symbol = GetBaseSymbolOrDefault(member, semanticModel, cancellationToken);
 
                 if (symbol is not null)
                 {
@@ -182,7 +182,7 @@ internal static class ChangeAccessibilityRefactoring
                 }
                 case VariableDeclaratorSyntax variableDeclarator:
                 {
-                    if (variableDeclarator.Parent.Parent is MemberDeclarationSyntax memberDeclaration2)
+                    if (variableDeclarator.Parent!.Parent is MemberDeclarationSyntax memberDeclaration2)
                         yield return memberDeclaration2;
 
                     break;

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertBlockBodyToExpressionBodyRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertBlockBodyToExpressionBodyRefactoring.cs
@@ -48,12 +48,12 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
     public static bool CanRefactor(PropertyDeclarationSyntax propertyDeclaration, TextSpan? span = null)
     {
-        AccessorListSyntax accessorList = propertyDeclaration.AccessorList;
+        AccessorListSyntax? accessorList = propertyDeclaration.AccessorList;
 
         if (accessorList is not null
             && span?.IsEmptyAndContainedInSpanOrBetweenSpans(accessorList) != false)
         {
-            AccessorDeclarationSyntax accessor = propertyDeclaration
+            AccessorDeclarationSyntax? accessor = propertyDeclaration
                 .AccessorList?
                 .Accessors
                 .SingleOrDefault(shouldThrow: false);
@@ -100,12 +100,12 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
     public static bool CanRefactor(IndexerDeclarationSyntax indexerDeclaration, TextSpan? span = null)
     {
-        AccessorListSyntax accessorList = indexerDeclaration.AccessorList;
+        AccessorListSyntax? accessorList = indexerDeclaration.AccessorList;
 
         if (accessorList is not null
             && span?.IsEmptyAndContainedInSpanOrBetweenSpans(accessorList) != false)
         {
-            AccessorDeclarationSyntax accessor = indexerDeclaration
+            AccessorDeclarationSyntax? accessor = indexerDeclaration
                 .AccessorList?
                 .Accessors
                 .SingleOrDefault(shouldThrow: false);
@@ -138,7 +138,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
     public static bool CanRefactor(AccessorDeclarationSyntax accessorDeclaration, TextSpan? span = null)
     {
-        BlockSyntax body = accessorDeclaration.Body;
+        BlockSyntax? body = accessorDeclaration.Body;
 
         return body is not null
             && (span?.IsEmptyAndContainedInSpanOrBetweenSpans(accessorDeclaration) != false
@@ -193,11 +193,11 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
         if (newLinePosition == NewLinePosition.After)
         {
-            SyntaxToken arrowToken = CSharpUtility.GetExpressionBody(newNode).ArrowToken;
+            SyntaxToken arrowToken = CSharpUtility.GetExpressionBody(newNode)!.ArrowToken;
             var annotation = new SyntaxAnnotation();
             newNode = newNode.ReplaceToken(arrowToken, arrowToken.WithAdditionalAnnotations(annotation));
             document = await document.ReplaceNodeAsync(node, newNode, cancellationToken).ConfigureAwait(false);
-            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            SyntaxNode root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))!;
             arrowToken = root.GetAnnotatedTokens(annotation).Single();
             var textChange = new TextChange(TextSpan.FromBounds(arrowToken.GetPreviousToken().Span.End, arrowToken.SpanStart), " ");
             return await document.WithTextChangeAsync(textChange, cancellationToken).ConfigureAwait(false);
@@ -208,7 +208,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
     private static NewLinePosition GetNewLinePosition(Document document, SyntaxNode node, AnalyzerConfigOptions configOptions, CancellationToken cancellationToken)
     {
-        if (DiagnosticRules.PutExpressionBodyOnItsOwnLine.IsEffective(node.SyntaxTree, document.Project.CompilationOptions, cancellationToken)
+        if (DiagnosticRules.PutExpressionBodyOnItsOwnLine.IsEffective(node.SyntaxTree, document.Project.CompilationOptions!, cancellationToken)
             && ConvertExpressionBodyAnalysis.AllowPutExpressionBodyOnItsOwnLine(node.Kind()))
         {
             return configOptions.GetArrowTokenNewLinePosition();
@@ -228,7 +228,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
                 return methodDeclaration
                     .WithExpressionBody(CreateExpressionBody(analysis, methodDeclaration, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(methodDeclaration.Body, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(methodDeclaration.Body!, analysis))
                     .WithBody(null);
             }
             case SyntaxKind.ConstructorDeclaration:
@@ -238,7 +238,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
                 return constructorDeclaration
                     .WithExpressionBody(CreateExpressionBody(analysis, constructorDeclaration, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(constructorDeclaration.Body, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(constructorDeclaration.Body!, analysis))
                     .WithBody(null);
             }
             case SyntaxKind.DestructorDeclaration:
@@ -248,7 +248,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
                 return destructorDeclaration
                     .WithExpressionBody(CreateExpressionBody(analysis, destructorDeclaration, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(destructorDeclaration.Body, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(destructorDeclaration.Body!, analysis))
                     .WithBody(null);
             }
             case SyntaxKind.LocalFunctionStatement:
@@ -258,7 +258,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
                 return localFunction
                     .WithExpressionBody(CreateExpressionBody(analysis, localFunction, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(localFunction.Body, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(localFunction.Body!, analysis))
                     .WithBody(null);
             }
             case SyntaxKind.OperatorDeclaration:
@@ -268,7 +268,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
                 return operatorDeclaration
                     .WithExpressionBody(CreateExpressionBody(analysis, operatorDeclaration, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(operatorDeclaration.Body, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(operatorDeclaration.Body!, analysis))
                     .WithBody(null);
             }
             case SyntaxKind.ConversionOperatorDeclaration:
@@ -278,27 +278,27 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
                 return operatorDeclaration
                     .WithExpressionBody(CreateExpressionBody(analysis, operatorDeclaration, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(operatorDeclaration.Body, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(operatorDeclaration.Body!, analysis))
                     .WithBody(null);
             }
             case SyntaxKind.PropertyDeclaration:
             {
                 var propertyDeclaration = (PropertyDeclarationSyntax)node;
-                BlockExpressionAnalysis analysis = BlockExpressionAnalysis.Create(propertyDeclaration.AccessorList);
+                BlockExpressionAnalysis analysis = BlockExpressionAnalysis.Create(propertyDeclaration.AccessorList!);
 
                 return propertyDeclaration
                     .WithExpressionBody(CreateExpressionBody(analysis, propertyDeclaration, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(analysis.Block, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(analysis.Block!, analysis))
                     .WithAccessorList(null);
             }
             case SyntaxKind.IndexerDeclaration:
             {
                 var indexerDeclaration = (IndexerDeclarationSyntax)node;
-                BlockExpressionAnalysis analysis = BlockExpressionAnalysis.Create(indexerDeclaration.AccessorList);
+                BlockExpressionAnalysis analysis = BlockExpressionAnalysis.Create(indexerDeclaration.AccessorList!);
 
                 return indexerDeclaration
                     .WithExpressionBody(CreateExpressionBody(analysis, indexerDeclaration, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(analysis.Block, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(analysis.Block!, analysis))
                     .WithAccessorList(null);
             }
             case SyntaxKind.GetAccessorDeclaration:
@@ -312,7 +312,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
 
                 return accessor
                     .WithExpressionBody(CreateExpressionBody(analysis, accessor, configOptions, newLinePosition))
-                    .WithSemicolonToken(CreateSemicolonToken(analysis.Block, analysis))
+                    .WithSemicolonToken(CreateSemicolonToken(analysis.Block!, analysis))
                     .WithBody(null);
             }
             default:
@@ -331,7 +331,7 @@ internal static class ConvertBlockBodyToExpressionBodyRefactoring
     {
         SyntaxToken arrowToken = Token(SyntaxKind.EqualsGreaterThanToken);
 
-        ExpressionSyntax expression = analysis.Expression;
+        ExpressionSyntax expression = analysis.Expression!;
 
         SyntaxToken keyword = analysis.ReturnOrThrowKeyword;
 

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertCommentToDocumentationCommentRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertCommentToDocumentationCommentRefactoring.cs
@@ -89,12 +89,12 @@ internal static class ConvertCommentToDocumentationCommentRefactoring
 
         SyntaxToken token = trivia.Token;
 
-        EnumMemberDeclarationSyntax enumMemberDeclaration = token
+        EnumMemberDeclarationSyntax? enumMemberDeclaration = token
             .GetPreviousToken()
-            .Parent
+            .Parent!
             .FirstAncestorOrSelf<EnumMemberDeclarationSyntax>();
 
-        int enumMemberIndex = enumDeclaration.Members.IndexOf(enumMemberDeclaration);
+        int enumMemberIndex = enumDeclaration.Members.IndexOf(enumMemberDeclaration!);
 
         SyntaxTriviaList trailingTrivia = token.TrailingTrivia;
 

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertConditionalExpressionToIfElseRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertConditionalExpressionToIfElseRefactoring.cs
@@ -20,7 +20,7 @@ internal static class ConvertConditionalExpressionToIfElseRefactoring
 
     public const string RecursiveTitle = Title + " (recursively)";
 
-    public static (CodeAction codeAction, CodeAction recursiveCodeAction) ComputeRefactoring(
+    public static (CodeAction? codeAction, CodeAction? recursiveCodeAction) ComputeRefactoring(
         Document document,
         ConditionalExpressionSyntax conditionalExpression,
         in CodeActionData data,
@@ -28,12 +28,12 @@ internal static class ConvertConditionalExpressionToIfElseRefactoring
         SemanticModel semanticModel,
         CancellationToken cancellationToken = default)
     {
-        CodeAction codeAction = null;
-        CodeAction recursiveCodeAction = null;
+        CodeAction? codeAction = null;
+        CodeAction? recursiveCodeAction = null;
 
         ExpressionSyntax expression = conditionalExpression.WalkUpParentheses();
 
-        SyntaxNode parent = expression.Parent;
+        SyntaxNode parent = expression.Parent!;
 
         if (parent.IsKind(SyntaxKind.ReturnStatement, SyntaxKind.YieldReturnStatement))
         {
@@ -166,7 +166,7 @@ internal static class ConvertConditionalExpressionToIfElseRefactoring
     {
         VariableDeclaratorSyntax variableDeclarator = localDeclaration.Declaration.Variables[0];
 
-        LocalDeclarationStatementSyntax newLocalDeclaration = localDeclaration.RemoveNode(variableDeclarator.Initializer, SyntaxRemoveOptions.KeepExteriorTrivia);
+        LocalDeclarationStatementSyntax newLocalDeclaration = localDeclaration.RemoveNode(variableDeclarator.Initializer!, SyntaxRemoveOptions.KeepExteriorTrivia)!;
 
         TypeSyntax type = newLocalDeclaration.Declaration.Type;
 
@@ -174,7 +174,7 @@ internal static class ConvertConditionalExpressionToIfElseRefactoring
         {
             newLocalDeclaration = newLocalDeclaration.ReplaceNode(
                 type,
-                semanticModel.GetTypeSymbol(conditionalExpression, cancellationToken)
+                semanticModel.GetTypeSymbol(conditionalExpression, cancellationToken)!
                     .ToMinimalTypeSyntax(semanticModel, type.SpanStart)
                     .WithTriviaFrom(type));
         }
@@ -199,7 +199,7 @@ internal static class ConvertConditionalExpressionToIfElseRefactoring
         Func<ExpressionSyntax, StatementSyntax> createStatement,
         bool recursive = false)
     {
-        StatementSyntax statement = null;
+        StatementSyntax? statement = null;
 
         if (recursive
             && conditionalExpression.WhenTrue.WalkDownParentheses() is ConditionalExpressionSyntax whenTrue)

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertExpressionBodyToBlockBodyRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertExpressionBodyToBlockBodyRefactoring.cs
@@ -25,7 +25,7 @@ internal static class ConvertExpressionBodyToBlockBodyRefactoring
     {
         AnalyzerConfigOptions configOptions = document.GetConfigOptions(selectedMembers.Parent.SyntaxTree);
 
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         IEnumerable<MemberDeclarationSyntax> newMembers = selectedMembers
             .UnderlyingList
@@ -34,7 +34,7 @@ internal static class ConvertExpressionBodyToBlockBodyRefactoring
                 selectedMembers.Count,
                 member =>
                 {
-                    ArrowExpressionClauseSyntax expressionBody = CSharpUtility.GetExpressionBody(member);
+                    ArrowExpressionClauseSyntax? expressionBody = CSharpUtility.GetExpressionBody(member);
 
                     if (expressionBody is not null
                         && ExpandExpressionBodyAnalysis.IsFixable(expressionBody))
@@ -55,7 +55,7 @@ internal static class ConvertExpressionBodyToBlockBodyRefactoring
     {
         AnalyzerConfigOptions configOptions = document.GetConfigOptions(expressionBody.SyntaxTree);
 
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         SyntaxNode newNode = Refactor(expressionBody, configOptions, semanticModel, cancellationToken);
 
@@ -70,7 +70,7 @@ internal static class ConvertExpressionBodyToBlockBodyRefactoring
             newNode = newNode.ReplaceToken(token, newToken);
         }
 
-        return await document.ReplaceNodeAsync(expressionBody.Parent, newNode, cancellationToken).ConfigureAwait(false);
+        return await document.ReplaceNodeAsync(expressionBody.Parent!, newNode, cancellationToken).ConfigureAwait(false);
     }
 
     public static SyntaxNode Refactor(
@@ -79,9 +79,9 @@ internal static class ConvertExpressionBodyToBlockBodyRefactoring
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        SyntaxNode node = expressionBody.Parent;
+        SyntaxNode node = expressionBody.Parent!;
 
-        ExpressionSyntax expression = expressionBody.Expression;
+        ExpressionSyntax expression = expressionBody.Expression!;
 
         switch (node.Kind())
         {
@@ -232,7 +232,7 @@ internal static class ConvertExpressionBodyToBlockBodyRefactoring
                 case SyntaxKind.AwaitExpression:
                 {
                     ITypeSymbol originalDefinition = semanticModel
-                        .GetTypeSymbol(returnType, cancellationToken)
+                        .GetTypeSymbol(returnType, cancellationToken)!
                         .OriginalDefinition;
 
                     if (!originalDefinition.HasMetadataName(MetadataNames.System_Threading_Tasks_ValueTask_T)
@@ -286,7 +286,7 @@ internal static class ConvertExpressionBodyToBlockBodyRefactoring
             {
                 if (e is ThrowExpressionSyntax throwExpression)
                 {
-                    return ThrowStatement(Token(SyntaxKind.ThrowKeyword), throwExpression.Expression, s);
+                    return ThrowStatement(Token(SyntaxKind.ThrowKeyword), throwExpression.Expression!, s);
                 }
                 else
                 {

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertForEachToForRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertForEachToForRefactoring.cs
@@ -36,7 +36,7 @@ internal static class ConvertForEachToForRefactoring
 
         MemberAccessExpressionSyntax countOrLengthMemberAccess = SimpleMemberAccessExpression(
             forEachExpression.WithoutTrivia(),
-            IdentifierName(CSharpUtility.GetCountOrLengthPropertyName(forEachExpression, semanticModel, cancellationToken)));
+            IdentifierName(CSharpUtility.GetCountOrLengthPropertyName(forEachExpression, semanticModel, cancellationToken)!));
 
         VariableDeclarationSyntax declaration;
         BinaryExpressionSyntax condition;
@@ -99,7 +99,7 @@ internal static class ConvertForEachToForRefactoring
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        ILocalSymbol symbol = semanticModel.GetDeclaredSymbol(forEachStatement, cancellationToken);
+        ILocalSymbol? symbol = semanticModel.GetDeclaredSymbol(forEachStatement, cancellationToken);
 
         foreach (SyntaxNode node in forEachStatement.Statement.DescendantNodes())
         {

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertHasFlagCallToBitwiseOperationRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertHasFlagCallToBitwiseOperationRefactoring.cs
@@ -19,7 +19,7 @@ internal static class ConvertHasFlagCallToBitwiseOperationRefactoring
         InvocationExpressionSyntax invocation,
         CancellationToken cancellationToken = default)
     {
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         return await RefactorAsync(document, invocation, semanticModel, cancellationToken).ConfigureAwait(false);
     }
@@ -44,7 +44,7 @@ internal static class ConvertHasFlagCallToBitwiseOperationRefactoring
 
         SyntaxNode nodeToReplace = invocation;
 
-        SyntaxNode parent = invocation.Parent;
+        SyntaxNode parent = invocation.Parent!;
 
         if (!parent.SpanContainsDirectives())
         {

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertInterpolatedStringToStringBuilderMethodRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertInterpolatedStringToStringBuilderMethodRefactoring.cs
@@ -27,8 +27,8 @@ internal static class ConvertInterpolatedStringToStringBuilderMethodRefactoring
             {
                 var interpolation = (InterpolationSyntax)content;
 
-                InterpolationAlignmentClauseSyntax alignmentClause = interpolation.AlignmentClause;
-                InterpolationFormatClauseSyntax formatClause = interpolation.FormatClause;
+                InterpolationAlignmentClauseSyntax? alignmentClause = interpolation.AlignmentClause;
+                InterpolationFormatClauseSyntax? formatClause = interpolation.FormatClause;
 
                 if (alignmentClause is not null
                     || formatClause is not null)

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertLambdaBlockBodyToExpressionBodyRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertLambdaBlockBodyToExpressionBodyRefactoring.cs
@@ -21,7 +21,7 @@ internal static class ConvertLambdaBlockBodyToExpressionBodyRefactoring
     {
         var block = (BlockSyntax)lambda.Body;
 
-        ExpressionSyntax expression = GetExpression(block.Statements[0]).WithoutTrivia();
+        ExpressionSyntax expression = GetExpression(block.Statements[0])!.WithoutTrivia();
 
         LambdaExpressionSyntax newLambda = GetNewLambda()
             .WithTriviaFrom(lambda)
@@ -29,7 +29,7 @@ internal static class ConvertLambdaBlockBodyToExpressionBodyRefactoring
 
         return document.ReplaceNodeAsync(lambda, newLambda, cancellationToken);
 
-        static ExpressionSyntax GetExpression(StatementSyntax statement)
+        static ExpressionSyntax? GetExpression(StatementSyntax statement)
         {
             switch (statement.Kind())
             {
@@ -45,7 +45,7 @@ internal static class ConvertLambdaBlockBodyToExpressionBodyRefactoring
                 {
                     return ThrowExpression(
                         Token(SyntaxTriviaList.Empty, SyntaxKind.ThrowKeyword, TriviaList(Space)),
-                        ((ThrowStatementSyntax)statement).Expression);
+                        ((ThrowStatementSyntax)statement).Expression!);
                 }
             }
 

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertMethodGroupToAnonymousFunctionRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertMethodGroupToAnonymousFunctionRefactoring.cs
@@ -19,9 +19,9 @@ internal static class ConvertMethodGroupToAnonymousFunctionRefactoring
     {
         InvocationExpressionSyntax invocationExpression = InvocationExpression(expression);
 
-        IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(expression, cancellationToken);
+        IMethodSymbol methodSymbol = semanticModel.GetMethodSymbol(expression, cancellationToken)!;
 
-        LambdaExpressionSyntax lambda = null;
+        LambdaExpressionSyntax? lambda = null;
 
         ImmutableArray<IParameterSymbol> parameterSymbols = methodSymbol.Parameters;
 
@@ -39,8 +39,8 @@ internal static class ConvertMethodGroupToAnonymousFunctionRefactoring
         }
         else
         {
-            ParameterListSyntax parameterList = null;
-            ArgumentListSyntax argumentList = null;
+            ParameterListSyntax? parameterList = null;
+            ArgumentListSyntax? argumentList = null;
 
             if (parameterSymbols.Length == 0)
             {

--- a/src/Workspaces.Common/CSharp/Refactorings/CopyMemberDeclarationRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/CopyMemberDeclarationRefactoring.cs
@@ -27,7 +27,7 @@ internal static class CopyMemberDeclarationRefactoring
 
         if (identifier != default)
         {
-            SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
             string newName = identifier.ValueText;
 
@@ -35,9 +35,9 @@ internal static class CopyMemberDeclarationRefactoring
             {
                 newName = NameGenerator.Default.EnsureUniqueName(newName, semanticModel, member.SpanStart);
 
-                ISymbol symbol = semanticModel.GetDeclaredSymbol(member, cancellationToken);
+                ISymbol? symbol = semanticModel.GetDeclaredSymbol(member, cancellationToken);
 
-                ImmutableArray<SyntaxNode> references = await SyntaxFinder.FindReferencesAsync(symbol, document.Solution(), documents: ImmutableHashSet.Create(document), cancellationToken: cancellationToken).ConfigureAwait(false);
+                ImmutableArray<SyntaxNode> references = await SyntaxFinder.FindReferencesAsync(symbol!, document.Solution(), documents: ImmutableHashSet.Create(document), cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 SyntaxToken newIdentifier = SyntaxFactory.Identifier(newName);
 
@@ -65,7 +65,7 @@ internal static class CopyMemberDeclarationRefactoring
             newMember = newMember.WithNavigationAnnotation();
         }
 
-        MemberDeclarationListInfo memberList = SyntaxInfo.MemberDeclarationListInfo(member.Parent);
+        MemberDeclarationListInfo memberList = SyntaxInfo.MemberDeclarationListInfo(member.Parent!);
 
         int index = memberList.IndexOf(member);
 
@@ -110,7 +110,7 @@ internal static class CopyMemberDeclarationRefactoring
         {
             if (copyAfter)
             {
-                if (statementsInfos.ParentAsBlock.OpenBraceToken.GetFullSpanEndLine(cancellationToken: cancellationToken) == localFunction.GetFullSpanStartLine(cancellationToken: cancellationToken))
+                if (statementsInfos.ParentAsBlock!.OpenBraceToken.GetFullSpanEndLine(cancellationToken: cancellationToken) == localFunction.GetFullSpanStartLine(cancellationToken: cancellationToken))
                 {
                     localFunction = localFunction.WithLeadingTrivia(localFunction.GetLeadingTrivia().Insert(0, NewLine()));
                 }

--- a/src/Workspaces.Common/CSharp/Refactorings/ExtractTypeDeclarationToNewDocumentRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ExtractTypeDeclarationToNewDocumentRefactoring.cs
@@ -19,11 +19,11 @@ internal static class ExtractTypeDeclarationToNewDocumentRefactoring
         MemberDeclarationSyntax memberDeclaration,
         CancellationToken cancellationToken = default)
     {
-        SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        SyntaxNode root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))!;
 
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
-        SyntaxNode newRoot = root.ReplaceNode(memberDeclaration.Parent, RemoveNode(memberDeclaration));
+        SyntaxNode newRoot = root.ReplaceNode(memberDeclaration.Parent!, RemoveNode(memberDeclaration));
 
         newRoot = RemoveEmptyNamespaces(newRoot, SyntaxRemoveOptions.KeepUnbalancedDirectives);
 
@@ -47,7 +47,7 @@ internal static class ExtractTypeDeclarationToNewDocumentRefactoring
 
     private static SyntaxNode RemoveNode(MemberDeclarationSyntax member)
     {
-        MemberDeclarationListInfo memberList = SyntaxInfo.MemberDeclarationListInfo(member.Parent);
+        MemberDeclarationListInfo memberList = SyntaxInfo.MemberDeclarationListInfo(member.Parent!);
         SyntaxList<MemberDeclarationSyntax> members = memberList.Members;
 
         MemberDeclarationListInfo newMemberList = memberList.RemoveNode(member, SyntaxRemoveOptions.KeepUnbalancedDirectives);
@@ -77,16 +77,16 @@ internal static class ExtractTypeDeclarationToNewDocumentRefactoring
         IEnumerable<MemberDeclarationSyntax> membersToRemove = GetNonNestedTypeDeclarations(compilationUnit.Members)
             .Where(f => f != memberDeclaration);
 
-        CompilationUnitSyntax newCompilationUnit = compilationUnit.RemoveNodes(
+        CompilationUnitSyntax? newCompilationUnit = compilationUnit.RemoveNodes(
             membersToRemove,
             SyntaxRemoveOptions.KeepUnbalancedDirectives);
 
-        SyntaxList<AttributeListSyntax> attributeLists = newCompilationUnit.AttributeLists;
+        SyntaxList<AttributeListSyntax> attributeLists = newCompilationUnit!.AttributeLists;
 
         if (attributeLists.Any())
             newCompilationUnit = newCompilationUnit.RemoveNodes(attributeLists, SyntaxRemoveOptions.KeepUnbalancedDirectives);
 
-        return RemoveEmptyNamespaces(newCompilationUnit, SyntaxRemoveOptions.KeepUnbalancedDirectives);
+        return RemoveEmptyNamespaces(newCompilationUnit!, SyntaxRemoveOptions.KeepUnbalancedDirectives);
     }
 
     private static string GetDocumentName(MemberDeclarationSyntax memberDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
@@ -143,6 +143,6 @@ internal static class ExtractTypeDeclarationToNewDocumentRefactoring
             .Cast<NamespaceDeclarationSyntax>()
             .Where(f => !f.Members.Any());
 
-        return node.RemoveNodes(emptyNamespaces, removeOptions);
+        return node.RemoveNodes(emptyNamespaces, removeOptions)!;
     }
 }

--- a/src/Workspaces.Common/CSharp/Refactorings/GenerateBaseConstructorsRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/GenerateBaseConstructorsRefactoring.cs
@@ -83,7 +83,7 @@ internal static class GenerateBaseConstructorsRefactoring
 
         foreach (IParameterSymbol parameterSymbol in methodSymbol.Parameters)
         {
-            EqualsValueClauseSyntax @default = null;
+            EqualsValueClauseSyntax? @default = null;
 
             if (parameterSymbol.HasExplicitDefaultValue)
             {

--- a/src/Workspaces.Common/CSharp/Refactorings/IfRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/IfRefactoring.cs
@@ -47,7 +47,7 @@ internal static class IfRefactoring
 
                 VariableDeclaratorSyntax declarator = analysis.Statement.Declaration.Variables[0];
 
-                EqualsValueClauseSyntax initializer = declarator.Initializer;
+                EqualsValueClauseSyntax? initializer = declarator.Initializer;
 
                 EqualsValueClauseSyntax newInitializer = (initializer is not null)
                     ? initializer.WithValue(conditionalExpression)
@@ -201,7 +201,7 @@ internal static class IfRefactoring
         IfStatementSyntax ifStatement = analysis.IfStatement;
         int position = ifStatement.SpanStart;
 
-        ITypeSymbol targetType = GetTargetType();
+        ITypeSymbol? targetType = GetTargetType();
 
         BinaryExpressionSyntax coalesceExpression = CreateCoalesceExpression(
             analysis.Left.WithoutTrivia(),
@@ -248,9 +248,9 @@ internal static class IfRefactoring
             return document.ReplaceNodeAsync(ifStatement, newNode, cancellationToken);
         }
 
-        ITypeSymbol GetTargetType()
+        ITypeSymbol? GetTargetType()
         {
-            IMethodSymbol methodSymbol = analysis.SemanticModel.GetEnclosingSymbol<IMethodSymbol>(position, cancellationToken);
+            IMethodSymbol? methodSymbol = analysis.SemanticModel.GetEnclosingSymbol<IMethodSymbol>(position, cancellationToken);
 
             Debug.Assert(methodSymbol is not null, "");
 
@@ -533,7 +533,7 @@ internal static class IfRefactoring
     private static BinaryExpressionSyntax CreateCoalesceExpression(
         ExpressionSyntax left,
         ExpressionSyntax right,
-        ITypeSymbol targetType,
+        ITypeSymbol? targetType,
         int position,
         SemanticModel semanticModel)
     {

--- a/src/Workspaces.Common/CSharp/Refactorings/InlineAliasExpressionRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/InlineAliasExpressionRefactoring.cs
@@ -16,27 +16,27 @@ internal static class InlineAliasExpressionRefactoring
         UsingDirectiveSyntax usingDirective,
         CancellationToken cancellationToken)
     {
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
-        IAliasSymbol aliasSymbol = semanticModel.GetDeclaredSymbol(usingDirective, cancellationToken);
+        IAliasSymbol? aliasSymbol = semanticModel.GetDeclaredSymbol(usingDirective, cancellationToken);
 
-        SyntaxNode parent = usingDirective.Parent;
+        SyntaxNode? parent = usingDirective.Parent;
 
 #if ROSLYN_4_0
-        Debug.Assert(parent.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.NamespaceDeclaration, SyntaxKind.FileScopedNamespaceDeclaration), "");
+        Debug.Assert(parent!.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.NamespaceDeclaration, SyntaxKind.FileScopedNamespaceDeclaration), "");
 #else
-        Debug.Assert(parent.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.NamespaceDeclaration), "");
+        Debug.Assert(parent!.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.NamespaceDeclaration), "");
 #endif
 
-        int index = SyntaxInfo.UsingDirectiveListInfo(parent).IndexOf(usingDirective);
+        int index = SyntaxInfo.UsingDirectiveListInfo(parent!).IndexOf(usingDirective);
 
-        var rewriter = new Rewriter(aliasSymbol, aliasSymbol.Target.ToTypeSyntax(), semanticModel, cancellationToken);
+        var rewriter = new Rewriter(aliasSymbol!, aliasSymbol!.Target.ToTypeSyntax(), semanticModel, cancellationToken);
 
-        SyntaxNode newNode = rewriter.Visit(parent);
+        SyntaxNode newNode = rewriter.Visit(parent)!;
 
         newNode = RemoveUsingDirective(newNode, index);
 
-        return await document.ReplaceNodeAsync(parent, newNode, cancellationToken).ConfigureAwait(false);
+        return await document.ReplaceNodeAsync(parent!, newNode, cancellationToken).ConfigureAwait(false);
     }
 
     private static SyntaxNode RemoveUsingDirective(SyntaxNode node, int index)
@@ -44,12 +44,12 @@ internal static class InlineAliasExpressionRefactoring
         switch (node)
         {
             case CompilationUnitSyntax compilationUnit:
-                return compilationUnit.RemoveNode(compilationUnit.Usings[index]);
+                return compilationUnit.RemoveNode(compilationUnit.Usings[index])!;
             case NamespaceDeclarationSyntax namespaceDeclaration:
-                return namespaceDeclaration.RemoveNode(namespaceDeclaration.Usings[index]);
+                return namespaceDeclaration.RemoveNode(namespaceDeclaration.Usings[index])!;
 #if ROSLYN_4_0
             case FileScopedNamespaceDeclarationSyntax fileScopedNamespaceDeclaration:
-                return fileScopedNamespaceDeclaration.RemoveNode(fileScopedNamespaceDeclaration.Usings[index]);
+                return fileScopedNamespaceDeclaration.RemoveNode(fileScopedNamespaceDeclaration.Usings[index])!;
 #endif
         }
 
@@ -74,9 +74,9 @@ internal static class InlineAliasExpressionRefactoring
 
         public CancellationToken CancellationToken { get; }
 
-        public override SyntaxNode VisitAliasQualifiedName(AliasQualifiedNameSyntax node)
+        public override SyntaxNode? VisitAliasQualifiedName(AliasQualifiedNameSyntax node)
         {
-            IAliasSymbol aliasSymbol = SemanticModel.GetAliasInfo(node.Alias, CancellationToken);
+            IAliasSymbol? aliasSymbol = SemanticModel.GetAliasInfo(node.Alias, CancellationToken);
             if (SymbolEqualityComparer.Default.Equals(aliasSymbol, AliasSymbol))
             {
                 return SyntaxFactory.QualifiedName((NameSyntax)Replacement, node.Name)
@@ -87,9 +87,9 @@ internal static class InlineAliasExpressionRefactoring
             return base.VisitAliasQualifiedName(node);
         }
 
-        public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
         {
-            IAliasSymbol aliasSymbol = SemanticModel.GetAliasInfo(node, CancellationToken);
+            IAliasSymbol? aliasSymbol = SemanticModel.GetAliasInfo(node, CancellationToken);
 
             if (SymbolEqualityComparer.Default.Equals(aliasSymbol, AliasSymbol))
             {

--- a/src/Workspaces.Common/CSharp/Refactorings/IntroduceFieldRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/IntroduceFieldRefactoring.cs
@@ -18,9 +18,9 @@ internal static class IntroduceFieldRefactoring
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        MemberDeclarationSyntax containingMember = expressionStatement.FirstAncestor<MemberDeclarationSyntax>();
+        MemberDeclarationSyntax containingMember = expressionStatement.FirstAncestor<MemberDeclarationSyntax>()!;
 
-        var containingType = (TypeDeclarationSyntax)containingMember.Parent;
+        var containingType = (TypeDeclarationSyntax)containingMember.Parent!;
 
         string name = NameGenerator.CreateName(typeSymbol, firstCharToLower: true) ?? DefaultNames.Variable;
 

--- a/src/Workspaces.Common/CSharp/Refactorings/IntroduceFieldToLockOnRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/IntroduceFieldToLockOnRefactoring.cs
@@ -20,14 +20,14 @@ internal static class IntroduceFieldToLockOnRefactoring
         LockStatementSyntax lockStatement,
         CancellationToken cancellationToken = default)
     {
-        MemberDeclarationSyntax containingMember = lockStatement.FirstAncestor<MemberDeclarationSyntax>();
+        MemberDeclarationSyntax? containingMember = lockStatement.FirstAncestor<MemberDeclarationSyntax>();
 
         Debug.Assert(containingMember is not null);
 
         if (containingMember is null)
             return document;
 
-        TypeDeclarationSyntax containingType = containingMember.FirstAncestor<TypeDeclarationSyntax>();
+        TypeDeclarationSyntax? containingType = containingMember.FirstAncestor<TypeDeclarationSyntax>();
 
         Debug.Assert(containingType is not null);
 
@@ -38,7 +38,7 @@ internal static class IntroduceFieldToLockOnRefactoring
 
         int index = members.IndexOf(containingMember);
 
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         string name = NameGenerator.Default.EnsureUniqueLocalName(
             LockObjectName,

--- a/src/Workspaces.Common/CSharp/Refactorings/IntroduceLocalVariableRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/IntroduceLocalVariableRefactoring.cs
@@ -58,7 +58,7 @@ internal static class IntroduceLocalVariableRefactoring
         ExpressionSyntax expression,
         CancellationToken cancellationToken)
     {
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         string name = NameGenerator.Default.EnsureUniqueLocalName(DefaultNames.Variable, semanticModel, expression.SpanStart, cancellationToken: cancellationToken);
 

--- a/src/Workspaces.Common/CSharp/Refactorings/MarkTypeWithDebuggerDisplayAttributeRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/MarkTypeWithDebuggerDisplayAttributeRefactoring.cs
@@ -28,7 +28,7 @@ internal static class MarkTypeWithDebuggerDisplayAttributeRefactoring
 
         int position = newTypeDeclaration.Identifier.Span.End;
 
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         string propertyName = NameGenerator.Default.EnsureUniqueName(DefaultNames.DebuggerDisplayPropertyName, semanticModel, position);
 

--- a/src/Workspaces.Common/CSharp/Refactorings/ReduceIfNesting/ReduceIfNestingRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ReduceIfNesting/ReduceIfNestingRefactoring.cs
@@ -22,7 +22,7 @@ internal static partial class ReduceIfNestingRefactoring
 
         SyntaxNode node = statementsInfo.Parent;
 
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         var rewriter = new ReduceIfStatementRewriter(
             jumpKind,
@@ -31,7 +31,7 @@ internal static partial class ReduceIfNestingRefactoring
             semanticModel,
             cancellationToken);
 
-        SyntaxNode newNode = rewriter.Visit(node).WithFormatterAnnotation();
+        SyntaxNode newNode = rewriter.Visit(node)!.WithFormatterAnnotation();
 
         return await document.ReplaceNodeAsync(node, newNode, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Workspaces.Common/CSharp/Refactorings/ReduceIfNesting/ReduceIfNestingRewriter.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ReduceIfNesting/ReduceIfNestingRewriter.cs
@@ -101,7 +101,9 @@ internal static partial class ReduceIfNestingRefactoring
 
             if (ifStatement is not null
                 && ReduceIfNestingAnalysis.IsFixable(ifStatement))
+            {
                 return Rewrite(_statementsInfo, ifStatement);
+            }
 
             return node;
         }

--- a/src/Workspaces.Common/CSharp/Refactorings/ReduceIfNesting/ReduceIfNestingRewriter.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ReduceIfNesting/ReduceIfNestingRewriter.cs
@@ -67,7 +67,7 @@ internal static partial class ReduceIfNestingRefactoring
             }
         }
 
-        public override SyntaxNode VisitIfStatement(IfStatementSyntax node)
+        public override SyntaxNode? VisitIfStatement(IfStatementSyntax node)
         {
             if (node.Parent == _statementsInfo.Parent)
             {
@@ -77,7 +77,7 @@ internal static partial class ReduceIfNestingRefactoring
             return node;
         }
 
-        public override SyntaxNode VisitSwitchSection(SwitchSectionSyntax node)
+        public override SyntaxNode? VisitSwitchSection(SwitchSectionSyntax node)
         {
             if (_statementsInfo.Parent is null)
             {
@@ -87,7 +87,7 @@ internal static partial class ReduceIfNestingRefactoring
             return node;
         }
 
-        public override SyntaxNode VisitBlock(BlockSyntax node)
+        public override SyntaxNode? VisitBlock(BlockSyntax node)
         {
             if (_statementsInfo.Parent is null
                 && node.IsParentKind(SyntaxKind.SwitchSection))
@@ -97,15 +97,16 @@ internal static partial class ReduceIfNestingRefactoring
 
             _statementsInfo = new StatementListInfo(node);
 
-            IfStatementSyntax ifStatement = FindFixableIfStatement(_statementsInfo.Statements, _jumpKind);
+            IfStatementSyntax? ifStatement = FindFixableIfStatement(_statementsInfo.Statements, _jumpKind);
 
-            if (ReduceIfNestingAnalysis.IsFixable(ifStatement))
+            if (ifStatement is not null
+                && ReduceIfNestingAnalysis.IsFixable(ifStatement))
                 return Rewrite(_statementsInfo, ifStatement);
 
             return node;
         }
 
-        private static IfStatementSyntax FindFixableIfStatement(SyntaxList<StatementSyntax> statements, SyntaxKind jumpKind)
+        private static IfStatementSyntax? FindFixableIfStatement(SyntaxList<StatementSyntax> statements, SyntaxKind jumpKind)
         {
             int i = statements.Count - 1;
 
@@ -162,9 +163,9 @@ internal static partial class ReduceIfNestingRefactoring
             ExpressionSyntax newCondition = _logicalInverter.LogicallyInvert(ifStatement.Condition, _semanticModel, _cancellationToken);
 
             if (_recursive)
-                ifStatement = (IfStatementSyntax)VisitIfStatement(ifStatement);
+                ifStatement = (IfStatementSyntax)VisitIfStatement(ifStatement)!;
 
-            var block = (BlockSyntax)ifStatement.Statement;
+            var block = (BlockSyntax)ifStatement.Statement!;
 
             BlockSyntax newBlock = block.WithStatements(SingletonList(_jumpStatement));
 

--- a/src/Workspaces.Common/CSharp/Refactorings/RemoveAsyncAwait.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/RemoveAsyncAwait.cs
@@ -17,15 +17,15 @@ internal static class RemoveAsyncAwait
         SyntaxToken asyncKeyword,
         CancellationToken cancellationToken = default)
     {
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
-        SyntaxNode node = asyncKeyword.Parent;
+        SyntaxNode? node = asyncKeyword.Parent;
 
         var remover = new AwaitRemover(semanticModel, cancellationToken);
 
         SyntaxNode newNode = GetNewNode();
 
-        return await document.ReplaceNodeAsync(node, newNode, cancellationToken).ConfigureAwait(false);
+        return await document.ReplaceNodeAsync(node!, newNode, cancellationToken).ConfigureAwait(false);
 
         SyntaxNode GetNewNode()
         {
@@ -34,23 +34,23 @@ internal static class RemoveAsyncAwait
                 case MethodDeclarationSyntax methodDeclaration:
                 {
                     return remover
-                        .VisitMethodDeclaration(methodDeclaration)
+                        .VisitMethodDeclaration(methodDeclaration)!
                         .RemoveModifier(SyntaxKind.AsyncKeyword);
                 }
                 case LocalFunctionStatementSyntax localFunction:
                 {
-                    BlockSyntax body = localFunction.Body;
+                    BlockSyntax? body = localFunction.Body;
 
                     if (body is not null)
                     {
-                        localFunction = localFunction.WithBody((BlockSyntax)remover.VisitBlock(body));
+                        localFunction = localFunction.WithBody((BlockSyntax)remover.VisitBlock(body)!);
                     }
                     else
                     {
-                        ArrowExpressionClauseSyntax expressionBody = localFunction.ExpressionBody;
+                        ArrowExpressionClauseSyntax? expressionBody = localFunction.ExpressionBody;
 
                         if (expressionBody is not null)
-                            localFunction = localFunction.WithExpressionBody((ArrowExpressionClauseSyntax)remover.VisitArrowExpressionClause(expressionBody));
+                            localFunction = localFunction.WithExpressionBody((ArrowExpressionClauseSyntax)remover.VisitArrowExpressionClause(expressionBody)!);
                     }
 
                     return localFunction.RemoveModifier(SyntaxKind.AsyncKeyword);
@@ -116,35 +116,35 @@ internal static class RemoveAsyncAwait
                 var memberAccess = invocation.Expression as MemberAccessExpressionSyntax;
 
                 if (string.Equals(memberAccess?.Name?.Identifier.ValueText, "ConfigureAwait", StringComparison.Ordinal))
-                    expression = memberAccess.Expression;
+                    expression = memberAccess!.Expression;
             }
 
             return expression.WithTriviaFrom(awaitExpression);
         }
 
-        public override SyntaxNode VisitAwaitExpression(AwaitExpressionSyntax node)
+        public override SyntaxNode? VisitAwaitExpression(AwaitExpressionSyntax node)
         {
-            node = (AwaitExpressionSyntax)base.VisitAwaitExpression(node);
+            node = (AwaitExpressionSyntax)base.VisitAwaitExpression(node)!;
 
             return ExtractExpressionFromAwait(node, SemanticModel, CancellationToken);
         }
 
-        public override SyntaxNode VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax node)
+        public override SyntaxNode? VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax node)
         {
             return node;
         }
 
-        public override SyntaxNode VisitParenthesizedLambdaExpression(ParenthesizedLambdaExpressionSyntax node)
+        public override SyntaxNode? VisitParenthesizedLambdaExpression(ParenthesizedLambdaExpressionSyntax node)
         {
             return node;
         }
 
-        public override SyntaxNode VisitAnonymousMethodExpression(AnonymousMethodExpressionSyntax node)
+        public override SyntaxNode? VisitAnonymousMethodExpression(AnonymousMethodExpressionSyntax node)
         {
             return node;
         }
 
-        public override SyntaxNode VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)
+        public override SyntaxNode? VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)
         {
             return node;
         }

--- a/src/Workspaces.Common/CSharp/Refactorings/RemoveBracesFromIfElseElseRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/RemoveBracesFromIfElseElseRefactoring.cs
@@ -22,7 +22,7 @@ internal static class RemoveBracesFromIfElseElseRefactoring
 
     private class SyntaxRewriter : CSharpSyntaxRewriter
     {
-        private IfStatementSyntax _previousIf;
+        private IfStatementSyntax? _previousIf;
 
         private SyntaxRewriter()
         {
@@ -33,7 +33,7 @@ internal static class RemoveBracesFromIfElseElseRefactoring
             return (IfStatementSyntax)new SyntaxRewriter().Visit(node);
         }
 
-        public override SyntaxNode VisitIfStatement(IfStatementSyntax node)
+        public override SyntaxNode? VisitIfStatement(IfStatementSyntax node)
         {
             if (_previousIf?.Equals(node.GetPreviousIf()) != false)
             {
@@ -54,9 +54,9 @@ internal static class RemoveBracesFromIfElseElseRefactoring
             return base.VisitIfStatement(node);
         }
 
-        public override SyntaxNode VisitElseClause(ElseClauseSyntax node)
+        public override SyntaxNode? VisitElseClause(ElseClauseSyntax node)
         {
-            if (_previousIf.Equals(node.Parent)
+            if (_previousIf!.Equals(node.Parent)
                 && node.Statement?.Kind() == SyntaxKind.Block)
             {
                 return node.WithStatement(((BlockSyntax)node.Statement).Statements[0]);

--- a/src/Workspaces.Common/CSharp/Refactorings/SplitVariableDeclarationRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/SplitVariableDeclarationRefactoring.cs
@@ -40,14 +40,15 @@ internal static class SplitVariableDeclarationRefactoring
         VariableDeclarationSyntax variableDeclaration,
         CancellationToken cancellationToken = default)
     {
-        switch (variableDeclaration.Parent.Kind())
+        SyntaxNode parent = variableDeclaration.Parent!;
+        switch (parent.Kind())
         {
             case SyntaxKind.LocalDeclarationStatement:
-                return await SplitLocalDeclarationAsync(document, (LocalDeclarationStatementSyntax)variableDeclaration.Parent, cancellationToken).ConfigureAwait(false);
+                return await SplitLocalDeclarationAsync(document, (LocalDeclarationStatementSyntax)parent, cancellationToken).ConfigureAwait(false);
             case SyntaxKind.FieldDeclaration:
-                return await SplitFieldDeclarationAsync(document, (FieldDeclarationSyntax)variableDeclaration.Parent, cancellationToken).ConfigureAwait(false);
+                return await SplitFieldDeclarationAsync(document, (FieldDeclarationSyntax)parent, cancellationToken).ConfigureAwait(false);
             case SyntaxKind.EventFieldDeclaration:
-                return await SplitEventFieldDeclarationAsync(document, (EventFieldDeclarationSyntax)variableDeclaration.Parent, cancellationToken).ConfigureAwait(false);
+                return await SplitEventFieldDeclarationAsync(document, (EventFieldDeclarationSyntax)parent, cancellationToken).ConfigureAwait(false);
             default:
                 throw new InvalidOperationException();
         }
@@ -72,7 +73,7 @@ internal static class SplitVariableDeclarationRefactoring
         FieldDeclarationSyntax declaration,
         CancellationToken cancellationToken)
     {
-        var containingMember = (TypeDeclarationSyntax)declaration.Parent;
+        var containingMember = (TypeDeclarationSyntax)declaration.Parent!;
 
         SyntaxList<MemberDeclarationSyntax> members = containingMember.Members;
 
@@ -90,7 +91,7 @@ internal static class SplitVariableDeclarationRefactoring
         EventFieldDeclarationSyntax declaration,
         CancellationToken cancellationToken)
     {
-        var containingMember = (TypeDeclarationSyntax)declaration.Parent;
+        var containingMember = (TypeDeclarationSyntax)declaration.Parent!;
 
         SyntaxList<MemberDeclarationSyntax> members = containingMember.Members;
 

--- a/src/Workspaces.Common/CSharp/Refactorings/UseLambdaInsteadOfAnonymousMethodRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/UseLambdaInsteadOfAnonymousMethodRefactoring.cs
@@ -18,7 +18,7 @@ internal static class UseLambdaInsteadOfAnonymousMethodRefactoring
     {
         ExpressionSyntax newNode = ParenthesizedLambdaExpression(
             anonymousMethod.AsyncKeyword,
-            anonymousMethod.ParameterList,
+            anonymousMethod.ParameterList!,
             Token(SyntaxKind.EqualsGreaterThanToken),
             anonymousMethod.Block);
 

--- a/src/Workspaces.Common/CSharp/Refactorings/UseMethodChainingRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/UseMethodChainingRefactoring.cs
@@ -20,13 +20,13 @@ internal static class UseMethodChainingRefactoring
         ExpressionStatementSyntax expressionStatement,
         CancellationToken cancellationToken)
     {
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         InvocationExpressionSyntax invocationExpression = GetInvocationExpression(expressionStatement);
 
         SimpleMemberInvocationExpressionInfo invocationInfo = SyntaxInfo.SimpleMemberInvocationExpressionInfo(invocationExpression);
 
-        ITypeSymbol returnType = semanticModel.GetMethodSymbol(invocationExpression, cancellationToken).ReturnType;
+        ITypeSymbol returnType = semanticModel.GetMethodSymbol(invocationExpression, cancellationToken)!.ReturnType;
 
         string name = ((IdentifierNameSyntax)UseMethodChainingAnalysis.WalkDownMethodChain(invocationInfo).Expression).Identifier.ValueText;
 
@@ -108,7 +108,7 @@ internal static class UseMethodChainingRefactoring
         }
         else
         {
-            return SyntaxInfo.SimpleAssignmentExpressionInfo(expression).Right as InvocationExpressionSyntax;
+            return (SyntaxInfo.SimpleAssignmentExpressionInfo(expression).Right as InvocationExpressionSyntax)!;
         }
     }
 }

--- a/src/Workspaces.Common/CSharp/Refactorings/UseReadOnlyFieldInsteadOfConstantRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/UseReadOnlyFieldInsteadOfConstantRefactoring.cs
@@ -21,11 +21,11 @@ internal static class UseReadOnlyFieldInsteadOfConstantRefactoring
             .RemoveModifier(SyntaxKind.ConstKeyword)
             .InsertModifier(SyntaxKind.ReadOnlyKeyword);
 
-        var containingDeclaration = (MemberDeclarationSyntax)field.Parent;
+        var containingDeclaration = (MemberDeclarationSyntax?)field.Parent;
 
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
-        if (semanticModel.GetDeclaredSymbol(containingDeclaration, cancellationToken)?.IsStatic == true)
+        if (semanticModel.GetDeclaredSymbol(containingDeclaration!, cancellationToken)?.IsStatic == true)
         {
             newField = newField.InsertModifier(SyntaxKind.StaticKeyword);
         }

--- a/src/Workspaces.Common/CSharp/SyntaxFormatter.cs
+++ b/src/Workspaces.Common/CSharp/SyntaxFormatter.cs
@@ -95,7 +95,7 @@ internal static class SyntaxFormatter
             }
         }
 
-        SyntaxNode parent = initializer.Parent;
+        SyntaxNode parent = initializer.Parent!;
 
         SyntaxNode newParent;
 
@@ -107,7 +107,7 @@ internal static class SyntaxFormatter
 
                 expression = expression.WithInitializer(newInitializer);
 
-                ArgumentListSyntax argumentList = expression.ArgumentList;
+                ArgumentListSyntax? argumentList = expression.ArgumentList;
 
                 if (argumentList is not null)
                 {
@@ -126,7 +126,7 @@ internal static class SyntaxFormatter
 
                 expression = expression.WithInitializer(newInitializer);
 
-                ArgumentListSyntax argumentList = expression.ArgumentList;
+                ArgumentListSyntax? argumentList = expression.ArgumentList;
 
                 if (argumentList is not null)
                 {
@@ -311,7 +311,7 @@ internal static class SyntaxFormatter
 
     public static InitializerExpressionSyntax ToMultiLine(InitializerExpressionSyntax initializer, AnalyzerConfigOptions configOptions, CancellationToken cancellationToken)
     {
-        SyntaxNode parent = initializer.Parent;
+        SyntaxNode parent = initializer.Parent!;
 
         SyntaxTrivia endOfLine = DetermineEndOfLine(initializer);
 
@@ -388,7 +388,7 @@ internal static class SyntaxFormatter
         ExpressionSyntax expression,
         CancellationToken cancellationToken = default)
     {
-        SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel semanticModel = (await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false))!;
 
         return await WrapCallChainAsync(document, expression, semanticModel, cancellationToken).ConfigureAwait(false);
     }
@@ -406,7 +406,7 @@ internal static class SyntaxFormatter
         string indentation = Environment.NewLine + indentationAnalysis.GetIncreasedIndentation();
 
         TextChange? textChange = null;
-        List<TextChange> textChanges = null;
+        List<TextChange>? textChanges = null;
 
         foreach (SyntaxNode node in new MethodChain(expression))
         {
@@ -447,7 +447,7 @@ internal static class SyntaxFormatter
         }
         else
         {
-            return document.WithTextChangeAsync(textChange.Value, cancellationToken);
+            return document.WithTextChangeAsync(textChange!.Value, cancellationToken);
         }
 
         void AddTextChange(SyntaxToken operatorToken)
@@ -539,7 +539,7 @@ internal static class SyntaxFormatter
 
     private static AccessorDeclarationSyntax ToMultiLine(AccessorDeclarationSyntax accessor)
     {
-        BlockSyntax body = accessor.Body;
+        BlockSyntax? body = accessor.Body;
 
         if (body is not null)
         {

--- a/src/Workspaces.Common/CodeFixes/AbstractCodeFixProvider.cs
+++ b/src/Workspaces.Common/CodeFixes/AbstractCodeFixProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -23,12 +24,12 @@ public abstract class AbstractCodeFixProvider : CodeFixProvider
         return WellKnownFixAllProviders.BatchFixer;
     }
 
-    protected static string GetEquivalenceKey(Diagnostic diagnostic, string additionalKey1 = null, string additionalKey2 = null)
+    protected static string GetEquivalenceKey(Diagnostic diagnostic, string? additionalKey1 = null, string? additionalKey2 = null)
     {
         return EquivalenceKey.Create(diagnostic, additionalKey1, additionalKey2);
     }
 
-    protected static string GetEquivalenceKey(string key, string additionalKey1 = null, string additionalKey2 = null)
+    protected static string GetEquivalenceKey(string key, string? additionalKey1 = null, string? additionalKey2 = null)
     {
         return EquivalenceKey.Create(key, additionalKey1, additionalKey2);
     }
@@ -36,10 +37,10 @@ public abstract class AbstractCodeFixProvider : CodeFixProvider
     protected static bool TryFindFirstAncestorOrSelf<TNode>(
         SyntaxNode root,
         TextSpan span,
-        out TNode node,
+        [NotNullWhen(true)] out TNode? node,
         bool findInsideTrivia = false,
         bool getInnermostNodeForTie = true,
-        Func<TNode, bool> predicate = null,
+        Func<TNode, bool>? predicate = null,
         bool ascendOutOfTrivia = true) where TNode : SyntaxNode
     {
         node = root
@@ -54,10 +55,10 @@ public abstract class AbstractCodeFixProvider : CodeFixProvider
     protected static bool TryFindFirstDescendantOrSelf<TNode>(
         SyntaxNode root,
         TextSpan span,
-        out TNode node,
+        [NotNullWhen(true)] out TNode? node,
         bool findInsideTrivia = false,
         bool getInnermostNodeForTie = true,
-        Func<SyntaxNode, bool> descendIntoChildren = null,
+        Func<SyntaxNode, bool>? descendIntoChildren = null,
         bool descendIntoTrivia = true) where TNode : SyntaxNode
     {
         node = root
@@ -72,10 +73,10 @@ public abstract class AbstractCodeFixProvider : CodeFixProvider
     protected static bool TryFindNode<TNode>(
         SyntaxNode root,
         TextSpan span,
-        out TNode node,
+        [NotNullWhen(true)] out TNode? node,
         bool findInsideTrivia = false,
         bool getInnermostNodeForTie = true,
-        Func<TNode, bool> predicate = null) where TNode : SyntaxNode
+        Func<TNode, bool>? predicate = null) where TNode : SyntaxNode
     {
         node = root.FindNode(span, findInsideTrivia: findInsideTrivia, getInnermostNodeForTie: getInnermostNodeForTie) as TNode;
 
@@ -130,7 +131,7 @@ public abstract class AbstractCodeFixProvider : CodeFixProvider
         }
 
         [Conditional("DEBUG")]
-        public static void NotNull<T>(T value) where T : class
+        public static void NotNull<T>(T? value) where T : class
         {
             Debug.Assert(value is not null, $"{nameof(value)} is null");
         }

--- a/src/Workspaces.Common/CommonWorkspaceExtensions.cs
+++ b/src/Workspaces.Common/CommonWorkspaceExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -13,7 +14,7 @@ internal static class CommonWorkspaceExtensions
         this Document document,
         SyntaxNode node,
         string optionKey,
-        out string value)
+        [NotNullWhen(true)] out string? value)
     {
         return TryGetAnalyzerOptionValue(document, node.SyntaxTree, optionKey, out value);
     }
@@ -22,16 +23,16 @@ internal static class CommonWorkspaceExtensions
         this Document document,
         SyntaxToken token,
         string optionKey,
-        out string value)
+        [NotNullWhen(true)] out string? value)
     {
-        return TryGetAnalyzerOptionValue(document, token.SyntaxTree, optionKey, out value);
+        return TryGetAnalyzerOptionValue(document, token.SyntaxTree!, optionKey, out value);
     }
 
     public static bool TryGetAnalyzerOptionValue(
         this Document document,
         SyntaxTree syntaxTree,
         string optionKey,
-        out string value)
+        [NotNullWhen(true)] out string? value)
     {
         if (document
             .Project

--- a/src/Workspaces.Common/Workspaces.Common.csproj
+++ b/src/Workspaces.Common/Workspaces.Common.csproj
@@ -8,6 +8,7 @@
     <Version>$(RoslynatorVersion)</Version>
     <AssemblyName>$(RoslynatorDllPrefix)Roslynator.Workspaces.Common</AssemblyName>
     <RootNamespace>Roslynator</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Enable `<Nullable>enable</Nullable>` on `Roslynator.Common` and `Roslynator.Workspaces.Common` and annotate public APIs correctly (`string?` where values can be null) rather than making everything non-nullable.
- This is a source-breaking change for NRT consumers of types such as `ConfigOptionDescriptor`, `ConfigOptions`, `XmlCodeAnalysisConfig`, and `AbstractCodeFixProvider`. Analyzer implementation projects are unchanged.

Fixes #1817.

## Test plan
- [x] `Common` and `Workspaces.Common` build with `TreatWarningsAsErrors=true` (0 CS86xx)
- [x] Downstream `Analyzers.CodeFixes`, `Refactorings`, and `CodeFixes` still build
- [x] Analyzer, code-fix, and refactoring tests passed locally
- [ ] CI green