### PR TITLE
Bump version to 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2026-08-21
+
+### Fixed
+
+- Set Visual Studio extension `InstallationTarget` to API version `[17.14,)` so Marketplace publish succeeds (VsixPub0029; API 18.0 is experimental). Installable on Visual Studio 2022 17.14+ and Visual Studio 2026 ([VS 2026 extension compatibility](https://aka.ms/vs2026extensioncompat)).
+
 ## [5.0.0] - 2026-08-21
 
 ### Added
@@ -28,8 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump Roslyn to 5.0.0 ([PR](https://github.com/dotnet/roslynator/pull/1787))
   - CLI targets Roslyn 5.0.0
   - Solution build and tests use Roslyn 5.0.0 by default (the testing *packages* floor at 3.8.0; see Breaking)
-- Replace Visual Studio 2022 extension with **Roslynator 2026** for Visual Studio 2026 (`[18.0,19.0)`) ([PR](https://github.com/dotnet/roslynator/pull/1787))
+- Replace Visual Studio 2022 extension with **Roslynator 2026** (`josefpihrt.Roslynator2026`) ([PR](https://github.com/dotnet/roslynator/pull/1787))
   - Extension ships refactorings and compiler diagnostic code fixes; analyzers via NuGet
+  - Intended install range was later corrected to API `[17.14,)` in 5.0.1 (Marketplace rejects API 18.0)
   - [Roslynator 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022) remains available as the last 4.x VSIX
 - Visual Studio Code extension ships refactorings and compiler diagnostic code fixes only ([PR](https://github.com/dotnet/roslynator/pull/1787))
   - Analyzers require Roslynator NuGet packages

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Analyzers are not included in Roslynator IDE extensions. Use Roslynator NuGet pa
 ## Tools
 
 - IDE extensions for:
-  - [Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026) (refactorings and compiler diagnostic fixes; analyzers via NuGet)
-  - [Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022) (last 4.x release; pin or use NuGet packages)
+  - [Roslynator 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026) (VS 2022 17.14+ and VS 2026; refactorings and compiler diagnostic fixes; analyzers via NuGet)
+  - [Roslynator 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022) (last 4.x release; pin or use NuGet packages)
   - [VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator) (refactorings and compiler diagnostic fixes; analyzers via NuGet)
     - Requires legacy OmniSharp (`dotnet.server.useOmnisharp`: `true`). With C# Dev Kit, use NuGet packages instead.
   - [Open VSX](https://open-vsx.org/extension/josefpihrt-vscode/roslynator)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Analyzers are not included in Roslynator IDE extensions. Use Roslynator NuGet pa
 
 ## Tools
 
-- IDE extensions for:
+- IDE extensions:
   - [Roslynator 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026) (VS 2022 17.14+ and VS 2026; refactorings and compiler diagnostic fixes; analyzers via NuGet)
   - [Roslynator 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022) (last 4.x release; pin or use NuGet packages)
   - [VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator) (refactorings and compiler diagnostic fixes; analyzers via NuGet)

--- a/src/Analyzers.CodeFixes/docs/NuGetReadme.md
+++ b/src/Analyzers.CodeFixes/docs/NuGetReadme.md
@@ -24,7 +24,7 @@ A collection of 200+ [analyzers](https://josefpihrt.github.io/docs/roslynator/an
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/CSharp.Workspaces/docs/NuGetReadme.md
+++ b/src/CSharp.Workspaces/docs/NuGetReadme.md
@@ -9,7 +9,7 @@ This package extends the functionality of the [Microsoft.CodeAnalysis.CSharp.Wor
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/CSharp/docs/NuGetReadme.md
+++ b/src/CSharp/docs/NuGetReadme.md
@@ -9,7 +9,7 @@ This package extends the functionality of the [Microsoft.CodeAnalysis.CSharp](ht
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/CodeAnalysis.Analyzers.CodeFixes/docs/NuGetReadme.md
+++ b/src/CodeAnalysis.Analyzers.CodeFixes/docs/NuGetReadme.md
@@ -26,7 +26,7 @@ Use this package for projects that reference Roslyn (`Microsoft.CodeAnalysis*`) 
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/CodeFixes/docs/NuGetReadme.md
+++ b/src/CodeFixes/docs/NuGetReadme.md
@@ -27,7 +27,7 @@ Otherwise, use the IDE extension instead.
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/CommandLine/docs/NetCore/NuGetReadme.md
+++ b/src/CommandLine/docs/NetCore/NuGetReadme.md
@@ -37,7 +37,7 @@ See the [CLI documentation](https://josefpihrt.github.io/docs/roslynator/cli) fo
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Testing Framework](https://www.nuget.org/packages/Roslynator.Testing.CSharp.Xunit)

--- a/src/CommandLine/docs/NetFramework/NuGetReadme.md
+++ b/src/CommandLine/docs/NetFramework/NuGetReadme.md
@@ -34,7 +34,7 @@ See the [CLI documentation](https://josefpihrt.github.io/docs/roslynator/cli) fo
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Testing Framework](https://www.nuget.org/packages/Roslynator.Testing.CSharp.Xunit)

--- a/src/Core/docs/NuGetReadme.md
+++ b/src/Core/docs/NuGetReadme.md
@@ -9,7 +9,7 @@ This package extends the functionality of the [Microsoft.CodeAnalysis.Common](ht
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/Formatting.Analyzers.CodeFixes/docs/NuGetReadme.md
+++ b/src/Formatting.Analyzers.CodeFixes/docs/NuGetReadme.md
@@ -24,7 +24,7 @@ A collection of formatting [analyzers](https://josefpihrt.github.io/docs/roslyna
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/Refactorings/docs/NuGetReadme.md
+++ b/src/Refactorings/docs/NuGetReadme.md
@@ -27,7 +27,7 @@ Otherwise, use the IDE extension instead.
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/Tests/Testing.CSharp.MSTest/docs/NuGetReadme.md
+++ b/src/Tests/Testing.CSharp.MSTest/docs/NuGetReadme.md
@@ -27,7 +27,7 @@ Examples in the Roslynator repository:
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/Tests/Testing.CSharp.Xunit/docs/NuGetReadme.md
+++ b/src/Tests/Testing.CSharp.Xunit/docs/NuGetReadme.md
@@ -27,7 +27,7 @@ Examples in the Roslynator repository:
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/Tests/Testing.CSharp/docs/NuGetReadme.md
+++ b/src/Tests/Testing.CSharp/docs/NuGetReadme.md
@@ -9,7 +9,7 @@ A shared package used by the Roslynator Testing Framework. Do not install this p
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/Tests/Testing.Common/docs/NuGetReadme.md
+++ b/src/Tests/Testing.Common/docs/NuGetReadme.md
@@ -9,7 +9,7 @@ A shared package used by the Roslynator Testing Framework. Do not install this p
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)

--- a/src/VisualStudio/source.extension.vsixmanifest
+++ b/src/VisualStudio/source.extension.vsixmanifest
@@ -12,22 +12,22 @@
     <Tags>Roslyn;Refactoring;CodeAnalysis;C#;CSharp;Productivity</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[18.0,19.0)" Id="Microsoft.VisualStudio.Community">
+    <InstallationTarget Version="[17.14,)" Id="Microsoft.VisualStudio.Community">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[18.0,19.0)" Id="Microsoft.VisualStudio.Community">
+    <InstallationTarget Version="[17.14,)" Id="Microsoft.VisualStudio.Community">
         <ProductArchitecture>arm64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[18.0,19.0)" Id="Microsoft.VisualStudio.Pro">
+    <InstallationTarget Version="[17.14,)" Id="Microsoft.VisualStudio.Pro">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[18.0,19.0)" Id="Microsoft.VisualStudio.Pro">
+    <InstallationTarget Version="[17.14,)" Id="Microsoft.VisualStudio.Pro">
         <ProductArchitecture>arm64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[18.0,19.0)" Id="Microsoft.VisualStudio.Enterprise">
+    <InstallationTarget Version="[17.14,)" Id="Microsoft.VisualStudio.Enterprise">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[18.0,19.0)" Id="Microsoft.VisualStudio.Enterprise">
+    <InstallationTarget Version="[17.14,)" Id="Microsoft.VisualStudio.Enterprise">
         <ProductArchitecture>arm64</ProductArchitecture>
     </InstallationTarget>
   </Installation>

--- a/src/VisualStudioCode/package/CHANGELOG.md
+++ b/src/VisualStudioCode/package/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2026-08-21
+
+### Fixed
+
+- Set Visual Studio extension `InstallationTarget` to API version `[17.14,)` so Marketplace publish succeeds (VsixPub0029; API 18.0 is experimental). Installable on Visual Studio 2022 17.14+ and Visual Studio 2026 ([VS 2026 extension compatibility](https://aka.ms/vs2026extensioncompat)).
+
 ## [5.0.0] - 2026-08-21
 
 ### Added
@@ -28,8 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump Roslyn to 5.0.0 ([PR](https://github.com/dotnet/roslynator/pull/1787))
   - CLI targets Roslyn 5.0.0
   - Solution build and tests use Roslyn 5.0.0 by default (the testing *packages* floor at 3.8.0; see Breaking)
-- Replace Visual Studio 2022 extension with **Roslynator 2026** for Visual Studio 2026 (`[18.0,19.0)`) ([PR](https://github.com/dotnet/roslynator/pull/1787))
+- Replace Visual Studio 2022 extension with **Roslynator 2026** (`josefpihrt.Roslynator2026`) ([PR](https://github.com/dotnet/roslynator/pull/1787))
   - Extension ships refactorings and compiler diagnostic code fixes; analyzers via NuGet
+  - Intended install range was later corrected to API `[17.14,)` in 5.0.1 (Marketplace rejects API 18.0)
   - [Roslynator 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022) remains available as the last 4.x VSIX
 - Visual Studio Code extension ships refactorings and compiler diagnostic code fixes only ([PR](https://github.com/dotnet/roslynator/pull/1787))
   - Analyzers require Roslynator NuGet packages

--- a/src/Workspaces.Core/docs/NuGetReadme.md
+++ b/src/Workspaces.Core/docs/NuGetReadme.md
@@ -9,7 +9,7 @@ This package extends the functionality of the [Microsoft.CodeAnalysis.Workspaces
 
 ## Related Products
 
-* [Roslynator for Visual Studio 2026](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
+* [Roslynator 2026 (VS 2022 17.14+ / VS 2026)](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2026)
 * [Roslynator for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=josefpihrt.Roslynator2022)
 * [Roslynator for VS Code](https://marketplace.visualstudio.com/items?itemName=josefpihrt-vscode.roslynator)
 * [Roslynator Command-line Tool](https://www.nuget.org/packages/Roslynator.DotNet.Cli)


### PR DESCRIPTION
## Summary
- Fix Marketplace publish failure (VsixPub0029): set `InstallationTarget` to API `[17.14,)` so the Roslynator 2026 VSIX can upload
- Document installability on VS 2022 17.14+ and VS 2026 per [VS 2026 extension compatibility](https://aka.ms/vs2026extensioncompat)

## Test plan
- [ ] Confirm `source.extension.vsixmanifest` has no `18.0` lower bounds
- [ ] After merge + `v5.0.1` release, verify `publish_vs_extension` succeeds on the tag workflow


Made with [Cursor](https://cursor.com)